### PR TITLE
Performance bug capabilities added; rbtree reproduced

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4010,6 +4010,8 @@ void Executor::executePersistentMemoryFlush(ExecutionState &state,
       StatePair notPersisted = fork(state, Expr::createIsZero(alreadyPersisted) , true);
       if (notPersisted.first) {
         auto& goodState = *notPersisted.first;
+        os = goodState.addressSpace.findObject(mo);
+        assert(os && "Could not get ObjectState from notPersisted.first");
         wos = goodState.addressSpace.getWriteable(mo, os);
         assert(wos && "Could not get writeable ObjectState from notPersisted.first");
         ps = dyn_cast<PersistentState>(wos);
@@ -4020,6 +4022,8 @@ void Executor::executePersistentMemoryFlush(ExecutionState &state,
       if (notPersisted.second) {
         // offset is already persisted, should error!
         auto& errState = *notPersisted.second;
+        os = errState.addressSpace.findObject(mo);
+        assert(os && "Could not get ObjectState from notPersisted.second");
         wos = errState.addressSpace.getWriteable(mo, os);
         assert(wos && "Could not get writeable ObjectState from notPersisted.second");
         ps = dyn_cast<PersistentState>(wos);

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -439,6 +439,7 @@ private:
                              const char *suffix = NULL,
                              const llvm::Twine &longMessage = "");
   
+  void emitPmemError(ExecutionState &state, const std::unordered_set<std::string> &errors);
   /**
    * call error handler and terminate state for persistent memory errors.
    * For each state terminated, outputs the unique errors that this state caused, 

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -769,8 +769,11 @@ std::unordered_set<std::string> PersistentState::getRootCauses(
   return causes;
 }
 
-ref<Expr> PersistentState::isOffsetPersisted(ref<Expr> offset) const {
-  return isCacheLinePersisted(getCacheLine(offset));
+ref<Expr> PersistentState::isOffsetAlreadyPersisted(ref<Expr> offset) const {
+  ref<Expr> cacheLine = getCacheLine(offset);
+  ref<Expr> result = ReadExpr::create(pendingCacheLineUpdates,
+                                      ZExtExpr::create(cacheLine, Expr::Int32));
+  return result;
 }
 
 ref<Expr> PersistentState::isCacheLinePersisted(unsigned cacheLine) const {

--- a/lib/Core/Memory.cpp
+++ b/lib/Core/Memory.cpp
@@ -769,6 +769,10 @@ std::unordered_set<std::string> PersistentState::getRootCauses(
   return causes;
 }
 
+ref<Expr> PersistentState::isOffsetPersisted(ref<Expr> offset) const {
+  return isCacheLinePersisted(getCacheLine(offset));
+}
+
 ref<Expr> PersistentState::isCacheLinePersisted(unsigned cacheLine) const {
   return isCacheLinePersisted(ConstantExpr::create(cacheLine, Expr::Int32));
 }

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -453,7 +453,8 @@ class PersistentState : public ObjectState {
     bool mustBePersisted(TimingSolver *solver, ExecutionState &state) const;
 
     std::string getLocationInfo(const ExecutionState &state);
-    ref<Expr> isOffsetPersisted(ref<Expr> offset) const;
+    // check from PENDING cache line updates if it's clean or not
+    ref<Expr> isOffsetAlreadyPersisted(ref<Expr> offset) const;
 
     static ref<ConstantExpr> getPersistedExpr();
     static ref<ConstantExpr> getDirtyExpr();

--- a/lib/Core/Memory.h
+++ b/lib/Core/Memory.h
@@ -452,6 +452,9 @@ class PersistentState : public ObjectState {
 
     bool mustBePersisted(TimingSolver *solver, ExecutionState &state) const;
 
+    std::string getLocationInfo(const ExecutionState &state);
+    ref<Expr> isOffsetPersisted(ref<Expr> offset) const;
+
     static ref<ConstantExpr> getPersistedExpr();
     static ref<ConstantExpr> getDirtyExpr();
     static ref<ConstantExpr> getNullptr();
@@ -472,8 +475,6 @@ class PersistentState : public ObjectState {
     ref<Expr> getCacheLine(ref<Expr> offset) const;
     unsigned numCacheLines() const;
     unsigned cacheLineSize() const;
-
-    std::string getLocationInfo(const ExecutionState &state);
 };
   
 } // End klee namespace

--- a/nvmbugs/000_pmdk_btree_map/CMakeLists.txt
+++ b/nvmbugs/000_pmdk_btree_map/CMakeLists.txt
@@ -12,6 +12,12 @@ set(CLEAN_SRC
     btree_map.h
 )
 
+set(PERF_SRC
+    driver.c
+    btree_map_performance_fixed.c
+    btree_map.h
+)
+
 include_directories(${PMDK_INCLUDE_DIR})
 link_directories(${PMDK_LIB_DIR})
 
@@ -27,6 +33,7 @@ add_custom_target(LINK_CLEAN COMMAND llvm-link-8 -o ${CLEAN_EXEC}.linked.bc ${CL
 add_dependencies(LINK_CLEAN EXTRACT_CLEAN)
 
 klee_add_test_executable(TARGET 000_Buggy SOURCES ${BUGGY_SRC} EXTRA_LIBS pmemobj pmem)
+klee_add_test_executable(TARGET 000_Performance_Fixed SOURCES ${PERF_SRC} EXTRA_LIBS pmemobj pmem)
 # target_link_libraries(000_Buggy pmemobj pmem)
 
 set(TEST_SRC

--- a/nvmbugs/000_pmdk_btree_map/btree_map_buggy.c
+++ b/nvmbugs/000_pmdk_btree_map/btree_map_buggy.c
@@ -92,7 +92,6 @@ btree_map_clear(PMEMobjpool *pop, TOID(struct btree_map) map)
 {
 	int ret = 0;
 	TX_BEGIN(pop) {
-		// btree_map_clear_node(D_RO(map)->root);
 		if (!TOID_IS_NULL(D_RO(map)->root))
 			btree_map_clear_node(D_RO(map)->root);
 

--- a/nvmbugs/000_pmdk_btree_map/btree_map_buggy.c
+++ b/nvmbugs/000_pmdk_btree_map/btree_map_buggy.c
@@ -32,6 +32,9 @@
 
 /*
  * btree_map.c -- textbook implementation of btree /w preemptive splitting
+ * (stolerbs) thie implementation has the redundant add in btree_map_rotate_left
+ * and is lacking proper TX_ADD usage (incorrect persistence, incorrect
+ * performance)
  */
 
 #include <assert.h>

--- a/nvmbugs/000_pmdk_btree_map/btree_map_clean.c
+++ b/nvmbugs/000_pmdk_btree_map/btree_map_clean.c
@@ -32,6 +32,8 @@
 
 /*
  * btree_map.c -- textbook implementation of btree /w preemptive splitting
+ * (stolerbs) thie implementation has the redundant add in btree_map_rotate_left
+ * but has proper TX_ADD usage (correct persistence, incorrect performance)
  */
 
 #include <assert.h>
@@ -348,7 +350,7 @@ btree_map_rotate_left(TOID(struct tree_map_node) lsb,
 	TX_ADD_FIELD(parent, items[p - 1]);
 	D_RW(parent)->items[p - 1] = D_RO(lsb)->items[D_RO(lsb)->n - 1];
 
-  printf("\tCalling TX_ADD(node)\n");
+	printf("\tCalling TX_ADD(node)\n");
 	TX_ADD(node);
 	/* rotate the node children */
 	memmove(D_RW(node)->slots + 1, D_RO(node)->slots,

--- a/nvmbugs/000_pmdk_btree_map/btree_map_clean.c
+++ b/nvmbugs/000_pmdk_btree_map/btree_map_clean.c
@@ -348,6 +348,7 @@ btree_map_rotate_left(TOID(struct tree_map_node) lsb,
 	TX_ADD_FIELD(parent, items[p - 1]);
 	D_RW(parent)->items[p - 1] = D_RO(lsb)->items[D_RO(lsb)->n - 1];
 
+  printf("\tCalling TX_ADD(node)\n");
 	TX_ADD(node);
 	/* rotate the node children */
 	memmove(D_RW(node)->slots + 1, D_RO(node)->slots,

--- a/nvmbugs/000_pmdk_btree_map/btree_map_performance_fixed.c
+++ b/nvmbugs/000_pmdk_btree_map/btree_map_performance_fixed.c
@@ -32,6 +32,8 @@
 
 /*
  * btree_map.c -- textbook implementation of btree /w preemptive splitting
+ * (stolerbs) thie implementation removes the redundant add in btree_map_rotate_left
+ * and has proper TX_ADD usage (correct persistence, correct performance)
  */
 
 #include <assert.h>
@@ -350,7 +352,7 @@ btree_map_rotate_left(TOID(struct tree_map_node) lsb,
 
 	/* rotate the node children */
 	//(stolerbs) This is a performance bug, according to citation 30 in PMTest
-  printf("\tSkipping TX_ADD(node)\n");
+	printf("\tSkipping TX_ADD(node)\n");
 	//TX_ADD(node);
 	/* rotate the node children */
 	memmove(D_RW(node)->slots + 1, D_RO(node)->slots,

--- a/nvmbugs/000_pmdk_btree_map/btree_map_performance_fixed.c
+++ b/nvmbugs/000_pmdk_btree_map/btree_map_performance_fixed.c
@@ -348,7 +348,9 @@ btree_map_rotate_left(TOID(struct tree_map_node) lsb,
 	TX_ADD_FIELD(parent, items[p - 1]);
 	D_RW(parent)->items[p - 1] = D_RO(lsb)->items[D_RO(lsb)->n - 1];
 
-	TX_ADD(node);
+	/* rotate the node children */
+	//(stolerbs) This is a performance bug, according to citation 30 in PMTest
+	//TX_ADD(node);
 	/* rotate the node children */
 	memmove(D_RW(node)->slots + 1, D_RO(node)->slots,
 		sizeof(TOID(struct tree_map_node)) * (D_RO(node)->n));

--- a/nvmbugs/000_pmdk_btree_map/btree_map_performance_fixed.c
+++ b/nvmbugs/000_pmdk_btree_map/btree_map_performance_fixed.c
@@ -350,6 +350,7 @@ btree_map_rotate_left(TOID(struct tree_map_node) lsb,
 
 	/* rotate the node children */
 	//(stolerbs) This is a performance bug, according to citation 30 in PMTest
+  printf("\tSkipping TX_ADD(node)\n");
 	//TX_ADD(node);
 	/* rotate the node children */
 	memmove(D_RW(node)->slots + 1, D_RO(node)->slots,

--- a/nvmbugs/001_simple/CMakeLists.txt
+++ b/nvmbugs/001_simple/CMakeLists.txt
@@ -20,3 +20,19 @@ klee_add_test_object(TARGET 001_SimpleMod SOURCES
 klee_add_test_object(TARGET 001_SimpleBranchMod SOURCES
   branch_paths.c
 ) 
+
+klee_add_test_object(TARGET 001_DoubleFlushErr SOURCES
+  double_flush_err.c
+)
+
+klee_add_test_object(TARGET 001_DoubleFlushNoErr SOURCES
+  double_flush_no_err.c
+)
+
+klee_add_test_object(TARGET 001_CleanFlushErr SOURCES
+  clean_flush_err.c
+)
+
+klee_add_test_object(TARGET 001_MayFlushErr SOURCES
+  may_flush_err.c
+)

--- a/nvmbugs/001_simple/clean_flush_err.c
+++ b/nvmbugs/001_simple/clean_flush_err.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <immintrin.h>
+
+#include "klee/klee.h"
+
+#define BUF_LEN 16384
+
+int main() {
+
+  char pmemaddr[BUF_LEN];
+  klee_pmem_mark_persistent(pmemaddr, BUF_LEN, "pmem_stack_buffer");
+
+  // flushing a non-dirty line
+  _mm_clflush(&pmemaddr[0]);
+  _mm_sfence();
+
+  return 0;
+  
+}

--- a/nvmbugs/001_simple/double_flush_err.c
+++ b/nvmbugs/001_simple/double_flush_err.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <immintrin.h>
+
+#include "klee/klee.h"
+
+#define BUF_LEN 16384
+
+int main() {
+
+  char pmemaddr[BUF_LEN];
+  klee_pmem_mark_persistent(pmemaddr, BUF_LEN, "pmem_stack_buffer");
+
+  // On same cache line, don't need to flush twice!
+  pmemaddr[0] = 1;
+  pmemaddr[1] = 2;
+  _mm_clflush(&pmemaddr[0]);
+  _mm_clflush(&pmemaddr[1]);
+  _mm_sfence();
+
+  klee_pmem_check_persisted(&pmemaddr[0], sizeof(pmemaddr[0]));
+  klee_pmem_check_persisted(&pmemaddr[1], sizeof(pmemaddr[1]));
+  
+  return 0;
+  
+}

--- a/nvmbugs/001_simple/double_flush_no_err.c
+++ b/nvmbugs/001_simple/double_flush_no_err.c
@@ -1,0 +1,39 @@
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <immintrin.h>
+
+#include "klee/klee.h"
+
+#define BUF_LEN 16384
+
+int main() {
+
+  char pmemaddr[BUF_LEN];
+  klee_pmem_mark_persistent(pmemaddr, BUF_LEN, "pmem_stack_buffer");
+
+  // On same cache line, so only need to flush once
+  pmemaddr[0] = 1;
+  pmemaddr[1] = 2;
+  _mm_clflush(&pmemaddr[0]);
+
+  // On different cache lines, need to flush both
+  pmemaddr[1000] = 3;
+  pmemaddr[3000] = 4;
+  _mm_clflush(&pmemaddr[1000]);
+  _mm_clflush(&pmemaddr[3000]);
+
+  _mm_sfence();
+
+  klee_pmem_check_persisted(&pmemaddr[0], sizeof(pmemaddr[0]));
+  klee_pmem_check_persisted(&pmemaddr[1], sizeof(pmemaddr[1]));
+  klee_pmem_check_persisted(&pmemaddr[1000], sizeof(pmemaddr[1000]));
+  klee_pmem_check_persisted(&pmemaddr[3000], sizeof(pmemaddr[3000]));
+  
+  return 0;
+  
+}

--- a/nvmbugs/001_simple/may_flush_err.c
+++ b/nvmbugs/001_simple/may_flush_err.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <immintrin.h>
+
+#include "klee/klee.h"
+
+#define BUF_LEN 16384
+
+int main() {
+
+  char pmemaddr[BUF_LEN];
+  klee_pmem_mark_persistent(pmemaddr, BUF_LEN, "pmem_stack_buffer");
+
+  int a;
+  klee_make_symbolic(&a, sizeof(a), "a");
+  klee_assume(0 <= a & a < BUF_LEN);
+  pmemaddr[a] = 25;
+
+  // CacheLine 0 might be clean, or might be dirty!
+  _mm_clflush(&pmemaddr[0]);
+  _mm_sfence();
+
+  // might persist, might not!
+  klee_pmem_check_persisted(&pmemaddr[a], sizeof(pmemaddr[a]));
+  
+  return 0;
+  
+}

--- a/nvmbugs/001_simple/may_flush_err.c
+++ b/nvmbugs/001_simple/may_flush_err.c
@@ -22,7 +22,10 @@ int main() {
   pmemaddr[a] = 25;
 
   // CacheLine 0 might be clean, or might be dirty!
+  // if this results in error, then check persist must also fail
+  // since 'a' cannot be on the smae cache line as 0, which got flushed
   _mm_clflush(&pmemaddr[0]);
+
   _mm_sfence();
 
   // might persist, might not!

--- a/nvmbugs/001_simple/may_flush_err.c
+++ b/nvmbugs/001_simple/may_flush_err.c
@@ -23,7 +23,7 @@ int main() {
 
   // CacheLine 0 might be clean, or might be dirty!
   // if this results in error, then check persist must also fail
-  // since 'a' cannot be on the smae cache line as 0, which got flushed
+  // since 'a' cannot be on the same cache line as 0, which got flushed
   _mm_clflush(&pmemaddr[0]);
 
   _mm_sfence();

--- a/nvmbugs/001_simple/simple_nvm_mod.c
+++ b/nvmbugs/001_simple/simple_nvm_mod.c
@@ -10,7 +10,7 @@
 #include <klee/klee.h>
 
 /* copying 4k at a time to pmem for this example */
-#define BUF_LEN 4096
+#define BUF_LEN 4096*4
 
 int mod_function(char *addr) {
     addr[0] = 2;

--- a/nvmbugs/003_pmdk_rbtree_map/CMakeLists.txt
+++ b/nvmbugs/003_pmdk_rbtree_map/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.1) 
+set(BUGGY_SRC_RBTREE
+  driver.c
+  rbtree_map_buggy.c
+  tree_map.h
+  rbtree_map.h
+)
+
+set(CLEAN_SRC_RBTREE
+  driver.c
+  rbtree_map_clean.c
+  tree_map.h
+  rbtree_map.h
+)
+
+
+include_directories(${PMDK_INCLUDE_DIR})
+link_directories(${PMDK_LIB_DIR})
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O1 -Xclang -disable-llvm-passes -D__NO_STRING_INLINES -D_FORTIFY_SOURCE=0 -U__OPTIMIZE__")
+
+klee_add_test_executable(TARGET 003_Clean SOURCES ${CLEAN_SRC_RBTREE} EXTRA_LIBS pmemobj pmem)
+
+set(CLEAN_EXEC_RBTREE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/003_Clean)
+add_custom_target(EXTRACT_CLEAN_RBTREE COMMAND extract-bc ${CLEAN_EXEC_RBTREE} -o ${CLEAN_EXEC_RBTREE}.bc)
+add_dependencies(EXTRACT_CLEAN_RBTREE 003_Clean)
+add_custom_target(LINK_CLEAN_RBTREE COMMAND llvm-link-8 -o ${CLEAN_EXEC_RBTREE}.linked.bc ${CLEAN_EXEC_RBTREE}.bc ${PMDK_LIB_DIR}/libpmemobj.so.bc)
+add_dependencies(LINK_CLEAN_RBTREE EXTRACT_CLEAN_RBTREE)
+
+klee_add_test_executable(TARGET 003_Buggy SOURCES ${BUGGY_SRC_RBTREE} EXTRA_LIBS pmemobj pmem)

--- a/nvmbugs/003_pmdk_rbtree_map/driver.c
+++ b/nvmbugs/003_pmdk_rbtree_map/driver.c
@@ -1,0 +1,98 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+#include <errno.h>
+#include <emmintrin.h>
+#include <immintrin.h>
+
+#include "tree_map.h"
+#include "rbtree_map.h"
+
+typedef struct driver_root {
+  size_t num_nodes;
+  TOID(struct tree_map) tree;
+} driver_root_t;
+
+POBJ_LAYOUT_BEGIN(003_driver);
+POBJ_LAYOUT_ROOT(003_driver, driver_root_t);
+POBJ_LAYOUT_END(003_driver);
+
+
+TOID_DECLARE(uint64_t, TREE_MAP_TYPE_OFFSET + 2);
+
+int main(int argc, const char *argv[]) {
+
+  if (argc <= 2) {
+    fprintf(stderr, "%s: path n_entries\n", argv[0]);
+    return -1;
+  }
+
+  uint64_t n_entries = (uint64_t)atoi(argv[2]);
+  // (void*)pop is actually the mmap-ed region...
+  PMEMobjpool *pop = pmemobj_create(argv[1], POBJ_LAYOUT_NAME(003_driver), PMEMOBJ_MIN_POOL, 0666);
+  if (pop == NULL) {
+    printf("Create failed, trying open layout %s. (%s)\n", POBJ_LAYOUT_NAME(003_driver), strerror(errno));
+    pop = pmemobj_open(argv[1], POBJ_LAYOUT_NAME(003_driver));
+  }
+
+  if (pop == NULL) {
+    printf("Object pool is null! (%s)\n", strerror(errno));
+    exit(1);
+  }
+
+  printf("Getting root from pool (%p)...\n", pop);
+
+  TOID(driver_root_t) root = POBJ_ROOT(pop, driver_root_t);
+  
+  assert(!TOID_IS_NULL(root) && "Root is null!");
+  assert(TOID_VALID(root) && "Root is invalid!");
+  printf("\troot.oid.offset: %lu\n", root.oid.off);
+  printf("\troot._type: %p\n", root._type);
+  printf("\troot._type_num: %d\n", root._type_num);
+  assert(D_RO(root) && "Root direct is null!");
+
+  printf("Checking persistent state...\n");
+  TX_BEGIN(pop) {
+    printf("Asserting root is either null or valid...\n");
+    assert(TOID_IS_NULL(D_RO(root)->tree) || TOID_VALID(D_RO(root)->tree));
+    printf("Assertion passed!\n");
+
+    if (!TOID_IS_NULL(D_RO(root)->tree) && !tree_map_is_empty(D_RO(root)->tree)) {
+      printf("\t+ Removing old nodes...\n");
+      assert(!tree_map_delete(pop, &D_RW(root)->tree) && "Could not delete tree!");
+      printf("\t+ Free-ing old allocation...\n");
+      TX_FREE(D_RO(root)->tree);
+    }
+
+    printf("\tChecking tree_map for old nodes...\n");
+    TX_SET(root, num_nodes, 0);
+    TX_SET(root, tree, TX_ZNEW(struct tree_map));
+    tree_map_new(pop, &D_RW(root)->tree);
+  } TX_END
+
+  printf("tree_map is now clean.\n");
+
+  for (uint64_t i = 0; i < n_entries; ++i) {
+    TX_BEGIN(pop) {
+      TOID(uint64_t) val = TX_NEW(uint64_t);
+      TX_ADD(val);
+      *D_RW(val) = i;
+      assert(!tree_map_insert(pop, D_RO(root)->tree, i, val.oid));
+      TX_SET(root, num_nodes, D_RO(root)->num_nodes + 1);
+    } TX_END
+    printf("Size is now %lu!\n", D_RO(root)->num_nodes);
+  }
+
+  for (uint64_t i = 0; i < n_entries; ++i) {
+    PMEMoid val = tree_map_get(D_RO(root)->tree, i);
+    uint64_t *ptr = pmemobj_direct(val);
+    assert(OID_INSTANCEOF(val, uint64_t) && ptr && *ptr == i);
+    printf("\t%lu => %lu\n", i, *ptr);
+  }
+
+  printf("Closing and exiting now...\n");
+  pmemobj_close(pop);
+
+  return 0;
+}

--- a/nvmbugs/003_pmdk_rbtree_map/rbtree_map.h
+++ b/nvmbugs/003_pmdk_rbtree_map/rbtree_map.h
@@ -1,0 +1,37 @@
+#ifndef	RBTREE_MAP_H
+#define	RBTREE_MAP_H
+
+#include "tree_map.h"
+
+#include <libpmemobj.h>
+
+TOID_DECLARE(struct tree_map_node, TREE_MAP_TYPE_OFFSET + 1);
+
+enum rb_color {
+	COLOR_BLACK,
+	COLOR_RED,
+
+	MAX_COLOR
+};
+
+enum rb_children {
+	RB_LEFT,
+	RB_RIGHT,
+
+	MAX_RB
+};
+
+struct tree_map_node {
+	uint64_t key;
+	PMEMoid value;
+	enum rb_color color;
+	TOID(struct tree_map_node) parent;
+	TOID(struct tree_map_node) slots[MAX_RB];
+};
+
+struct tree_map {
+	TOID(struct tree_map_node) sentinel;
+	TOID(struct tree_map_node) root;
+};
+
+#endif /* RBTREE_MAP_H */

--- a/nvmbugs/003_pmdk_rbtree_map/rbtree_map_buggy.c
+++ b/nvmbugs/003_pmdk_rbtree_map/rbtree_map_buggy.c
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * rbtree.c -- red-black tree implementation /w sentinel nodes
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include "tree_map.h"
+#include "rbtree_map.h"
+
+#define	NODE_P(_n)\
+D_RW(_n)->parent
+
+#define	NODE_GRANDP(_n)\
+NODE_P(NODE_P(_n))
+
+#define	NODE_PARENT_AT(_n, _rbc)\
+D_RW(NODE_P(_n))->slots[_rbc]
+
+#define	NODE_PARENT_LEFT(_n)\
+NODE_PARENT_AT(_n, RB_LEFT)
+
+#define	NODE_PARENT_RIGHT(_n)\
+NODE_PARENT_AT(_n, RB_RIGHT)
+
+#define	NODE_IS(_n, _rbc)\
+TOID_EQUALS(_n, NODE_PARENT_AT(_n, _rbc))
+
+#define	NODE_IS_LEFT(_n)\
+TOID_EQUALS(_n, NODE_PARENT_LEFT(_n))
+
+#define	NODE_IS_RIGHT(_n)\
+TOID_EQUALS(_n, NODE_PARENT_RIGHT(_n))
+
+#define	NODE_LOCATION(_n)\
+NODE_IS_RIGHT(_n)
+
+#define	RB_FIRST(_m)\
+D_RW(D_RW(_m)->root)->slots[RB_LEFT]
+
+#define	NODE_IS_NULL(_n)\
+TOID_EQUALS(_n, s)
+
+/*
+ * tree_map_new -- allocates a new red-black tree instance
+ */
+int
+tree_map_new(PMEMobjpool *pop, TOID(struct tree_map) *map)
+{
+	int ret = 0;
+	TX_BEGIN(pop) {
+		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		*map = TX_ZNEW(struct tree_map);
+
+		TOID(struct tree_map_node) s = TX_ZNEW(struct tree_map_node);
+		D_RW(s)->color = COLOR_BLACK;
+		D_RW(s)->parent = s;
+		D_RW(s)->slots[RB_LEFT] = s;
+		D_RW(s)->slots[RB_RIGHT] = s;
+
+		TOID(struct tree_map_node) r = TX_ZNEW(struct tree_map_node);
+		D_RW(r)->color = COLOR_BLACK;
+		D_RW(r)->parent = s;
+		D_RW(r)->slots[RB_LEFT] = s;
+		D_RW(r)->slots[RB_RIGHT] = s;
+
+		D_RW(*map)->sentinel = s;
+		D_RW(*map)->root = r;
+	} TX_ONABORT {
+		ret = 1;
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_delete -- cleanups and frees crit-bit tree instance
+ */
+int
+tree_map_delete(PMEMobjpool *pop, TOID(struct tree_map) *map)
+{
+	int ret = 0;
+	TX_BEGIN(pop) {
+		tree_map_clear(pop, *map);
+		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_FREE(*map);
+		*map = TOID_NULL(struct tree_map);
+	} TX_ONABORT {
+		ret = 1;
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_rotate -- (internal) performs a left/right rotation around a node
+ */
+static void
+tree_map_rotate(TOID(struct tree_map) map,
+	TOID(struct tree_map_node) node, enum rb_children c)
+{
+	TOID(struct tree_map_node) child = D_RO(node)->slots[!c];
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	TX_ADD(node);
+	TX_ADD(child);
+
+	D_RW(node)->slots[!c] = D_RO(child)->slots[c];
+
+	if (!TOID_EQUALS(D_RO(child)->slots[c], s))
+		TX_SET(D_RW(child)->slots[c], parent, node);
+
+	NODE_P(child) = NODE_P(node);
+
+	TX_ADD(NODE_P(node));
+	NODE_PARENT_AT(node, NODE_LOCATION(node)) = child;
+
+	D_RW(child)->slots[c] = node;
+	D_RW(node)->parent = child;
+}
+
+/*
+ * tree_map_insert_bst -- (internal) inserts a node in regular BST fashion
+ */
+static void
+tree_map_insert_bst(TOID(struct tree_map) map, TOID(struct tree_map_node) n)
+{
+	TOID(struct tree_map_node) parent = D_RO(map)->root;
+	TOID(struct tree_map_node) *dst = &RB_FIRST(map);
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	D_RW(n)->slots[RB_LEFT] = s;
+	D_RW(n)->slots[RB_RIGHT] = s;
+
+	while (!NODE_IS_NULL(*dst)) {
+		parent = *dst;
+		dst = &D_RW(*dst)->slots[D_RO(n)->key > D_RO(*dst)->key];
+	}
+
+	TX_SET(n, parent, parent);
+	*dst = n;
+}
+
+/*
+ * tree_map_recolor -- (internal) restores red-black tree properties
+ */
+TOID(struct tree_map_node)
+tree_map_recolor(TOID(struct tree_map) map,
+	TOID(struct tree_map_node) n, enum rb_children c)
+{
+	TOID(struct tree_map_node) uncle = D_RO(NODE_GRANDP(n))->slots[!c];
+
+	if (D_RO(uncle)->color == COLOR_RED) {
+		TX_SET(uncle, color, COLOR_BLACK);
+		TX_SET(NODE_P(n), color, COLOR_BLACK);
+		TX_SET(NODE_GRANDP(n), color, COLOR_RED);
+		return NODE_GRANDP(n);
+	} else {
+		if (NODE_IS(n, !c)) {
+			n = NODE_P(n);
+			tree_map_rotate(map, n, c);
+		}
+
+		TX_SET(NODE_P(n), color, COLOR_BLACK);
+		TX_SET(NODE_GRANDP(n), color, COLOR_RED);
+		tree_map_rotate(map, NODE_GRANDP(n), !c);
+	}
+
+	return n;
+}
+
+/*
+ * tree_map_insert -- inserts a new key-value pair into the map
+ */
+int
+tree_map_insert(PMEMobjpool *pop,
+	TOID(struct tree_map) map, uint64_t key, PMEMoid value)
+{
+	int ret = 0;
+
+	TX_BEGIN(pop) {
+		TOID(struct tree_map_node) n = TX_ZNEW(struct tree_map_node);
+		D_RW(n)->key = key;
+		D_RW(n)->value = value;
+
+		tree_map_insert_bst(map, n);
+
+		D_RW(n)->color = COLOR_RED;
+		while (D_RO(NODE_P(n))->color == COLOR_RED)
+			n = tree_map_recolor(map, n, NODE_LOCATION(NODE_P(n)));
+
+		TX_SET(RB_FIRST(map), color, COLOR_BLACK);
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_successor -- (internal) returns the successor of a node
+ */
+static TOID(struct tree_map_node)
+tree_map_successor(TOID(struct tree_map) map, TOID(struct tree_map_node) n)
+{
+	TOID(struct tree_map_node) dst = RB_FIRST(map);
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	if (!TOID_EQUALS(s, dst)) {
+		while (!NODE_IS_NULL(D_RO(dst)->slots[RB_LEFT]))
+			dst = D_RO(dst)->slots[RB_LEFT];
+	} else {
+		dst = D_RO(n)->parent;
+		while (TOID_EQUALS(n, D_RO(dst)->slots[RB_RIGHT])) {
+			n = dst;
+			dst = NODE_P(dst);
+		}
+		if (TOID_EQUALS(dst, D_RO(map)->root))
+			return s;
+	}
+
+	return dst;
+}
+
+/*
+ * tree_map_find_node -- (internal) returns the node that contains the key
+ */
+static TOID(struct tree_map_node)
+tree_map_find_node(TOID(struct tree_map) map, uint64_t key)
+{
+	TOID(struct tree_map_node) dst = RB_FIRST(map);
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	while (!NODE_IS_NULL(dst)) {
+		if (D_RO(dst)->key == key)
+			return dst;
+
+		dst = D_RO(dst)->slots[key > D_RO(dst)->key];
+	}
+
+	return TOID_NULL(struct tree_map_node);
+}
+
+/*
+ * tree_map_repair_branch -- (internal) restores red-black tree in one branch
+ */
+static TOID(struct tree_map_node)
+tree_map_repair_branch(TOID(struct tree_map) map,
+	TOID(struct tree_map_node) n, enum rb_children c)
+{
+	TOID(struct tree_map_node) sb = NODE_PARENT_AT(n, !c); /* sibling */
+	if (D_RO(sb)->color == COLOR_RED) {
+		TX_SET(sb, color, COLOR_BLACK);
+		TX_SET(NODE_P(n), color, COLOR_RED);
+		tree_map_rotate(map, NODE_P(n), c);
+		sb = NODE_PARENT_AT(n, !c);
+	}
+
+	if (D_RO(D_RO(sb)->slots[RB_RIGHT])->color == COLOR_BLACK &&
+		D_RO(D_RO(sb)->slots[RB_LEFT])->color == COLOR_BLACK) {
+		TX_SET(sb, color, COLOR_RED);
+		return D_RO(n)->parent;
+	} else {
+		if (D_RO(D_RO(sb)->slots[!c])->color == COLOR_BLACK) {
+			TX_SET(D_RW(sb)->slots[c], color, COLOR_BLACK);
+			TX_SET(sb, color, COLOR_RED);
+			tree_map_rotate(map, sb, !c);
+			sb = NODE_PARENT_AT(n, !c);
+		}
+		TX_SET(sb, color, D_RO(NODE_P(n))->color);
+		TX_SET(NODE_P(n), color, COLOR_BLACK);
+		TX_SET(D_RW(sb)->slots[!c], color, COLOR_BLACK);
+		tree_map_rotate(map, NODE_P(n), c);
+
+		return TOID_NULL(struct tree_map_node);
+	}
+
+	return n;
+}
+
+/*
+ * tree_map_repair -- (internal) restores red-black tree properties after remove
+ */
+static void
+tree_map_repair(TOID(struct tree_map) map, TOID(struct tree_map_node) n)
+{
+	/* if left, repair right sibling, otherwise repair left sibling. */
+	while (!TOID_IS_NULL(n) && D_RO(n)->color == COLOR_BLACK)
+		n = tree_map_repair_branch(map, n, NODE_LOCATION(n));
+}
+
+/*
+ * tree_map_remove -- removes key-value pair from the map
+ */
+PMEMoid
+tree_map_remove(PMEMobjpool *pop, TOID(struct tree_map) map, uint64_t key)
+{
+	PMEMoid ret = OID_NULL;
+
+	TOID(struct tree_map_node) n = tree_map_find_node(map, key);
+	if (TOID_IS_NULL(n))
+		return ret;
+
+	ret = D_RO(n)->value;
+
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+	TOID(struct tree_map_node) r = D_RO(map)->root;
+
+	TOID(struct tree_map_node) y = (NODE_IS_NULL(D_RO(n)->slots[RB_LEFT]) ||
+					NODE_IS_NULL(D_RO(n)->slots[RB_RIGHT]))
+					? n : tree_map_successor(map, n);
+
+	TOID(struct tree_map_node) x = NODE_IS_NULL(D_RO(y)->slots[RB_LEFT]) ?
+			D_RO(y)->slots[RB_RIGHT] : D_RO(y)->slots[RB_LEFT];
+
+	TX_BEGIN(pop) {
+		TX_ADD(x);
+		NODE_P(x) = NODE_P(y);
+		if (TOID_EQUALS(NODE_P(x), r)) {
+			TX_SET(r, slots[RB_LEFT], x);
+		} else {
+			TX_ADD(y);
+			NODE_PARENT_AT(y, NODE_LOCATION(y)) = x;
+		}
+
+		if (D_RO(y)->color == COLOR_BLACK)
+			tree_map_repair(map, x);
+
+		if (!TOID_EQUALS(y, n)) {
+			TX_ADD(y);
+			D_RW(y)->slots[RB_LEFT] = D_RO(n)->slots[RB_LEFT];
+			D_RW(y)->slots[RB_RIGHT] = D_RO(n)->slots[RB_RIGHT];
+			D_RW(y)->parent = D_RO(n)->parent;
+			D_RW(y)->color = D_RO(n)->color;
+			TX_SET(D_RW(n)->slots[RB_LEFT], parent, y);
+			TX_SET(D_RW(n)->slots[RB_RIGHT], parent, y);
+
+			TX_ADD(NODE_P(n));
+			NODE_PARENT_AT(n, NODE_LOCATION(n)) = y;
+		}
+		TX_FREE(n);
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_clear_node -- (internal) clears this node and its children
+ */
+static void
+tree_map_clear_node(TOID(struct tree_map) map, TOID(struct tree_map_node) p)
+{
+
+  TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+  if (!NODE_IS_NULL(D_RO(p)->slots[RB_LEFT])) {
+    tree_map_clear_node(map, D_RO(p)->slots[RB_LEFT]);
+  }
+  if (!NODE_IS_NULL(D_RO(p)->slots[RB_RIGHT])) {
+    tree_map_clear_node(map, D_RO(p)->slots[RB_RIGHT]);
+  }
+
+	pmemobj_tx_free(p.oid);
+}
+
+/*
+ * tree_map_clear -- removes all elements from the map
+ */
+int
+tree_map_clear(PMEMobjpool *pop,
+	TOID(struct tree_map) map)
+{
+	TX_BEGIN(pop) {
+		tree_map_clear_node(map, D_RW(map)->root);
+		TX_ADD_FIELD(map, root);
+    TX_ADD_FIELD(map, sentinel);
+
+    TX_FREE(D_RW(map)->sentinel);
+
+		D_RW(map)->root = TOID_NULL(struct tree_map_node);
+		D_RW(map)->sentinel = TOID_NULL(struct tree_map_node);
+	} TX_END
+
+	return 0;
+}
+
+/*
+ * tree_map_get -- searches for a value of the key
+ */
+PMEMoid
+tree_map_get(TOID(struct tree_map) map, uint64_t key)
+{
+	return D_RO(tree_map_find_node(map, key))->value;
+}
+
+/*
+ * tree_map_foreach_node -- (internal) recursively traverses tree
+ */
+static int
+tree_map_foreach_node(TOID(struct tree_map) map, TOID(struct tree_map_node) p,
+	int (*cb)(uint64_t key, PMEMoid value, void *arg), void *arg)
+{
+	int ret = 0;
+
+	if (TOID_EQUALS(p, D_RO(map)->sentinel))
+		return 0;
+
+	if ((ret = tree_map_foreach_node(map,
+		D_RO(p)->slots[RB_LEFT], cb, arg)) == 0) {
+		if ((ret = cb(D_RO(p)->key, D_RO(p)->value, arg)) == 0)
+			tree_map_foreach_node(map,
+				D_RO(p)->slots[RB_RIGHT], cb, arg);
+	}
+
+	return ret;
+}
+
+/*
+ * tree_map_foreach -- initiates recursive traversal
+ */
+int
+tree_map_foreach(TOID(struct tree_map) map,
+	int (*cb)(uint64_t key, PMEMoid value, void *arg), void *arg)
+{
+	return tree_map_foreach_node(map, RB_FIRST(map), cb, arg);
+}
+
+/*
+ * tree_map_is_empty -- checks whether the tree map is empty
+ */
+int
+tree_map_is_empty(TOID(struct tree_map) map)
+{
+	return TOID_IS_NULL(RB_FIRST(map));
+}

--- a/nvmbugs/003_pmdk_rbtree_map/rbtree_map_buggy.c
+++ b/nvmbugs/003_pmdk_rbtree_map/rbtree_map_buggy.c
@@ -32,6 +32,7 @@
 
 /*
  * rbtree.c -- red-black tree implementation /w sentinel nodes
+ * (stolerbs) this implementation does TX_ADD instead of TX_SET in 3 locations
  */
 
 #include <assert.h>
@@ -143,6 +144,7 @@ tree_map_rotate(TOID(struct tree_map) map,
 
 	NODE_P(child) = NODE_P(node);
 
+	//(stolerbs) This is the bug (loc 1)
 	TX_ADD(NODE_P(node));
 	NODE_PARENT_AT(node, NODE_LOCATION(node)) = child;
 
@@ -348,6 +350,7 @@ tree_map_remove(PMEMobjpool *pop, TOID(struct tree_map) map, uint64_t key)
 		if (TOID_EQUALS(NODE_P(x), r)) {
 			TX_SET(r, slots[RB_LEFT], x);
 		} else {
+			//(stolerbs) This is the bug (loc 2)
 			TX_ADD(y);
 			NODE_PARENT_AT(y, NODE_LOCATION(y)) = x;
 		}
@@ -364,6 +367,7 @@ tree_map_remove(PMEMobjpool *pop, TOID(struct tree_map) map, uint64_t key)
 			TX_SET(D_RW(n)->slots[RB_LEFT], parent, y);
 			TX_SET(D_RW(n)->slots[RB_RIGHT], parent, y);
 
+			//(stolerbs) This is the bug (loc 3)
 			TX_ADD(NODE_P(n));
 			NODE_PARENT_AT(n, NODE_LOCATION(n)) = y;
 		}

--- a/nvmbugs/003_pmdk_rbtree_map/rbtree_map_clean.c
+++ b/nvmbugs/003_pmdk_rbtree_map/rbtree_map_clean.c
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * rbtree.c -- red-black tree implementation /w sentinel nodes
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include "tree_map.h"
+#include "rbtree_map.h"
+
+#define	NODE_P(_n)\
+D_RW(_n)->parent
+
+#define	NODE_GRANDP(_n)\
+NODE_P(NODE_P(_n))
+
+#define	NODE_PARENT_AT(_n, _rbc)\
+D_RW(NODE_P(_n))->slots[_rbc]
+
+#define	NODE_PARENT_LEFT(_n)\
+NODE_PARENT_AT(_n, RB_LEFT)
+
+#define	NODE_PARENT_RIGHT(_n)\
+NODE_PARENT_AT(_n, RB_RIGHT)
+
+#define	NODE_IS(_n, _rbc)\
+TOID_EQUALS(_n, NODE_PARENT_AT(_n, _rbc))
+
+#define	NODE_IS_LEFT(_n)\
+TOID_EQUALS(_n, NODE_PARENT_LEFT(_n))
+
+#define	NODE_IS_RIGHT(_n)\
+TOID_EQUALS(_n, NODE_PARENT_RIGHT(_n))
+
+#define	NODE_LOCATION(_n)\
+NODE_IS_RIGHT(_n)
+
+#define	RB_FIRST(_m)\
+D_RW(D_RW(_m)->root)->slots[RB_LEFT]
+
+#define	NODE_IS_NULL(_n)\
+TOID_EQUALS(_n, s)
+
+/*
+ * tree_map_new -- allocates a new red-black tree instance
+ */
+int
+tree_map_new(PMEMobjpool *pop, TOID(struct tree_map) *map)
+{
+	int ret = 0;
+	TX_BEGIN(pop) {
+		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		*map = TX_ZNEW(struct tree_map);
+
+		TOID(struct tree_map_node) s = TX_ZNEW(struct tree_map_node);
+		D_RW(s)->color = COLOR_BLACK;
+		D_RW(s)->parent = s;
+		D_RW(s)->slots[RB_LEFT] = s;
+		D_RW(s)->slots[RB_RIGHT] = s;
+
+		TOID(struct tree_map_node) r = TX_ZNEW(struct tree_map_node);
+		D_RW(r)->color = COLOR_BLACK;
+		D_RW(r)->parent = s;
+		D_RW(r)->slots[RB_LEFT] = s;
+		D_RW(r)->slots[RB_RIGHT] = s;
+
+		D_RW(*map)->sentinel = s;
+		D_RW(*map)->root = r;
+	} TX_ONABORT {
+		ret = 1;
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_delete -- cleanups and frees crit-bit tree instance
+ */
+int
+tree_map_delete(PMEMobjpool *pop, TOID(struct tree_map) *map)
+{
+	int ret = 0;
+	TX_BEGIN(pop) {
+		tree_map_clear(pop, *map);
+		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_FREE(*map);
+		*map = TOID_NULL(struct tree_map);
+	} TX_ONABORT {
+		ret = 1;
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_rotate -- (internal) performs a left/right rotation around a node
+ */
+static void
+tree_map_rotate(TOID(struct tree_map) map,
+	TOID(struct tree_map_node) node, enum rb_children c)
+{
+	TOID(struct tree_map_node) child = D_RO(node)->slots[!c];
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	TX_ADD(node);
+	TX_ADD(child);
+
+	D_RW(node)->slots[!c] = D_RO(child)->slots[c];
+
+	if (!TOID_EQUALS(D_RO(child)->slots[c], s))
+		TX_SET(D_RW(child)->slots[c], parent, node);
+
+	NODE_P(child) = NODE_P(node);
+
+	TX_SET(NODE_P(node), slots[NODE_LOCATION(node)], child);
+
+	D_RW(child)->slots[c] = node;
+	D_RW(node)->parent = child;
+}
+
+/*
+ * tree_map_insert_bst -- (internal) inserts a node in regular BST fashion
+ */
+static void
+tree_map_insert_bst(TOID(struct tree_map) map, TOID(struct tree_map_node) n)
+{
+	TOID(struct tree_map_node) parent = D_RO(map)->root;
+	TOID(struct tree_map_node) *dst = &RB_FIRST(map);
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	D_RW(n)->slots[RB_LEFT] = s;
+	D_RW(n)->slots[RB_RIGHT] = s;
+
+	while (!NODE_IS_NULL(*dst)) {
+		parent = *dst;
+		dst = &D_RW(*dst)->slots[D_RO(n)->key > D_RO(*dst)->key];
+	}
+
+	TX_SET(n, parent, parent);
+	*dst = n;
+}
+
+/*
+ * tree_map_recolor -- (internal) restores red-black tree properties
+ */
+TOID(struct tree_map_node)
+tree_map_recolor(TOID(struct tree_map) map,
+	TOID(struct tree_map_node) n, enum rb_children c)
+{
+	TOID(struct tree_map_node) uncle = D_RO(NODE_GRANDP(n))->slots[!c];
+
+	if (D_RO(uncle)->color == COLOR_RED) {
+		TX_SET(uncle, color, COLOR_BLACK);
+		TX_SET(NODE_P(n), color, COLOR_BLACK);
+		TX_SET(NODE_GRANDP(n), color, COLOR_RED);
+		return NODE_GRANDP(n);
+	} else {
+		if (NODE_IS(n, !c)) {
+			n = NODE_P(n);
+			tree_map_rotate(map, n, c);
+		}
+
+		TX_SET(NODE_P(n), color, COLOR_BLACK);
+		TX_SET(NODE_GRANDP(n), color, COLOR_RED);
+		tree_map_rotate(map, NODE_GRANDP(n), !c);
+	}
+
+	return n;
+}
+
+/*
+ * tree_map_insert -- inserts a new key-value pair into the map
+ */
+int
+tree_map_insert(PMEMobjpool *pop,
+	TOID(struct tree_map) map, uint64_t key, PMEMoid value)
+{
+	int ret = 0;
+
+	TX_BEGIN(pop) {
+		TOID(struct tree_map_node) n = TX_ZNEW(struct tree_map_node);
+		D_RW(n)->key = key;
+		D_RW(n)->value = value;
+
+		tree_map_insert_bst(map, n);
+
+		D_RW(n)->color = COLOR_RED;
+		while (D_RO(NODE_P(n))->color == COLOR_RED)
+			n = tree_map_recolor(map, n, NODE_LOCATION(NODE_P(n)));
+
+		TX_SET(RB_FIRST(map), color, COLOR_BLACK);
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_successor -- (internal) returns the successor of a node
+ */
+static TOID(struct tree_map_node)
+tree_map_successor(TOID(struct tree_map) map, TOID(struct tree_map_node) n)
+{
+	TOID(struct tree_map_node) dst = RB_FIRST(map);
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	if (!TOID_EQUALS(s, dst)) {
+		while (!NODE_IS_NULL(D_RO(dst)->slots[RB_LEFT]))
+			dst = D_RO(dst)->slots[RB_LEFT];
+	} else {
+		dst = D_RO(n)->parent;
+		while (TOID_EQUALS(n, D_RO(dst)->slots[RB_RIGHT])) {
+			n = dst;
+			dst = NODE_P(dst);
+		}
+		if (TOID_EQUALS(dst, D_RO(map)->root))
+			return s;
+	}
+
+	return dst;
+}
+
+/*
+ * tree_map_find_node -- (internal) returns the node that contains the key
+ */
+static TOID(struct tree_map_node)
+tree_map_find_node(TOID(struct tree_map) map, uint64_t key)
+{
+	TOID(struct tree_map_node) dst = RB_FIRST(map);
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+	while (!NODE_IS_NULL(dst)) {
+		if (D_RO(dst)->key == key)
+			return dst;
+
+		dst = D_RO(dst)->slots[key > D_RO(dst)->key];
+	}
+
+	return TOID_NULL(struct tree_map_node);
+}
+
+/*
+ * tree_map_repair_branch -- (internal) restores red-black tree in one branch
+ */
+static TOID(struct tree_map_node)
+tree_map_repair_branch(TOID(struct tree_map) map,
+	TOID(struct tree_map_node) n, enum rb_children c)
+{
+	TOID(struct tree_map_node) sb = NODE_PARENT_AT(n, !c); /* sibling */
+	if (D_RO(sb)->color == COLOR_RED) {
+		TX_SET(sb, color, COLOR_BLACK);
+		TX_SET(NODE_P(n), color, COLOR_RED);
+		tree_map_rotate(map, NODE_P(n), c);
+		sb = NODE_PARENT_AT(n, !c);
+	}
+
+	if (D_RO(D_RO(sb)->slots[RB_RIGHT])->color == COLOR_BLACK &&
+		D_RO(D_RO(sb)->slots[RB_LEFT])->color == COLOR_BLACK) {
+		TX_SET(sb, color, COLOR_RED);
+		return D_RO(n)->parent;
+	} else {
+		if (D_RO(D_RO(sb)->slots[!c])->color == COLOR_BLACK) {
+			TX_SET(D_RW(sb)->slots[c], color, COLOR_BLACK);
+			TX_SET(sb, color, COLOR_RED);
+			tree_map_rotate(map, sb, !c);
+			sb = NODE_PARENT_AT(n, !c);
+		}
+		TX_SET(sb, color, D_RO(NODE_P(n))->color);
+		TX_SET(NODE_P(n), color, COLOR_BLACK);
+		TX_SET(D_RW(sb)->slots[!c], color, COLOR_BLACK);
+		tree_map_rotate(map, NODE_P(n), c);
+
+		return TOID_NULL(struct tree_map_node);
+	}
+
+	return n;
+}
+
+/*
+ * tree_map_repair -- (internal) restores red-black tree properties after remove
+ */
+static void
+tree_map_repair(TOID(struct tree_map) map, TOID(struct tree_map_node) n)
+{
+	/* if left, repair right sibling, otherwise repair left sibling. */
+	while (!TOID_IS_NULL(n) && D_RO(n)->color == COLOR_BLACK)
+		n = tree_map_repair_branch(map, n, NODE_LOCATION(n));
+}
+
+/*
+ * tree_map_remove -- removes key-value pair from the map
+ */
+PMEMoid
+tree_map_remove(PMEMobjpool *pop, TOID(struct tree_map) map, uint64_t key)
+{
+	PMEMoid ret = OID_NULL;
+
+	TOID(struct tree_map_node) n = tree_map_find_node(map, key);
+	if (TOID_IS_NULL(n))
+		return ret;
+
+	ret = D_RO(n)->value;
+
+	TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+	TOID(struct tree_map_node) r = D_RO(map)->root;
+
+	TOID(struct tree_map_node) y = (NODE_IS_NULL(D_RO(n)->slots[RB_LEFT]) ||
+					NODE_IS_NULL(D_RO(n)->slots[RB_RIGHT]))
+					? n : tree_map_successor(map, n);
+
+	TOID(struct tree_map_node) x = NODE_IS_NULL(D_RO(y)->slots[RB_LEFT]) ?
+			D_RO(y)->slots[RB_RIGHT] : D_RO(y)->slots[RB_LEFT];
+
+	TX_BEGIN(pop) {
+		TX_ADD(x);
+		NODE_P(x) = NODE_P(y);
+		if (TOID_EQUALS(NODE_P(x), r)) {
+			TX_SET(r, slots[RB_LEFT], x);
+		} else {
+			TX_SET(NODE_P(y), slots[NODE_LOCATION(y)], x);
+		}
+
+		if (D_RO(y)->color == COLOR_BLACK)
+			tree_map_repair(map, x);
+
+		if (!TOID_EQUALS(y, n)) {
+			TX_ADD(y);
+			D_RW(y)->slots[RB_LEFT] = D_RO(n)->slots[RB_LEFT];
+			D_RW(y)->slots[RB_RIGHT] = D_RO(n)->slots[RB_RIGHT];
+			D_RW(y)->parent = D_RO(n)->parent;
+			D_RW(y)->color = D_RO(n)->color;
+			TX_SET(D_RW(n)->slots[RB_LEFT], parent, y);
+			TX_SET(D_RW(n)->slots[RB_RIGHT], parent, y);
+
+			TX_SET(NODE_P(n), slots[NODE_LOCATION(n)], y);
+		}
+		TX_FREE(n);
+	} TX_END
+
+	return ret;
+}
+
+/*
+ * tree_map_clear_node -- (internal) clears this node and its children
+ */
+static void
+tree_map_clear_node(TOID(struct tree_map) map, TOID(struct tree_map_node) p)
+{
+
+  TOID(struct tree_map_node) s = D_RO(map)->sentinel;
+
+  if (!NODE_IS_NULL(D_RO(p)->slots[RB_LEFT])) {
+    tree_map_clear_node(map, D_RO(p)->slots[RB_LEFT]);
+  }
+  if (!NODE_IS_NULL(D_RO(p)->slots[RB_RIGHT])) {
+    tree_map_clear_node(map, D_RO(p)->slots[RB_RIGHT]);
+  }
+
+	pmemobj_tx_free(p.oid);
+}
+
+/*
+ * tree_map_clear -- removes all elements from the map
+ */
+int
+tree_map_clear(PMEMobjpool *pop,
+	TOID(struct tree_map) map)
+{
+	TX_BEGIN(pop) {
+		tree_map_clear_node(map, D_RW(map)->root);
+		TX_ADD_FIELD(map, root);
+    TX_ADD_FIELD(map, sentinel);
+
+    TX_FREE(D_RW(map)->sentinel);
+
+		D_RW(map)->root = TOID_NULL(struct tree_map_node);
+		D_RW(map)->sentinel = TOID_NULL(struct tree_map_node);
+	} TX_END
+
+	return 0;
+}
+
+/*
+ * tree_map_get -- searches for a value of the key
+ */
+PMEMoid
+tree_map_get(TOID(struct tree_map) map, uint64_t key)
+{
+	return D_RO(tree_map_find_node(map, key))->value;
+}
+
+/*
+ * tree_map_foreach_node -- (internal) recursively traverses tree
+ */
+static int
+tree_map_foreach_node(TOID(struct tree_map) map, TOID(struct tree_map_node) p,
+	int (*cb)(uint64_t key, PMEMoid value, void *arg), void *arg)
+{
+	int ret = 0;
+
+	if (TOID_EQUALS(p, D_RO(map)->sentinel))
+		return 0;
+
+	if ((ret = tree_map_foreach_node(map,
+		D_RO(p)->slots[RB_LEFT], cb, arg)) == 0) {
+		if ((ret = cb(D_RO(p)->key, D_RO(p)->value, arg)) == 0)
+			tree_map_foreach_node(map,
+				D_RO(p)->slots[RB_RIGHT], cb, arg);
+	}
+
+	return ret;
+}
+
+/*
+ * tree_map_foreach -- initiates recursive traversal
+ */
+int
+tree_map_foreach(TOID(struct tree_map) map,
+	int (*cb)(uint64_t key, PMEMoid value, void *arg), void *arg)
+{
+	return tree_map_foreach_node(map, RB_FIRST(map), cb, arg);
+}
+
+/*
+ * tree_map_is_empty -- checks whether the tree map is empty
+ */
+int
+tree_map_is_empty(TOID(struct tree_map) map)
+{
+	return TOID_IS_NULL(RB_FIRST(map));
+}

--- a/nvmbugs/003_pmdk_rbtree_map/rbtree_map_clean.c
+++ b/nvmbugs/003_pmdk_rbtree_map/rbtree_map_clean.c
@@ -32,6 +32,7 @@
 
 /*
  * rbtree.c -- red-black tree implementation /w sentinel nodes
+ * (stolerbs) this implementation uses TX_SET in 3 locations properly
  */
 
 #include <assert.h>

--- a/nvmbugs/003_pmdk_rbtree_map/simple_driver.c
+++ b/nvmbugs/003_pmdk_rbtree_map/simple_driver.c
@@ -1,0 +1,112 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+#include <errno.h>
+#include <emmintrin.h>
+#include <immintrin.h>
+
+#include "tree_map.h"
+#include "rbtree_map.h"
+
+typedef struct driver_root {
+  size_t num_nodes;
+  TOID(struct tree_map) tree;
+} driver_root_t;
+
+POBJ_LAYOUT_BEGIN(003_driver);
+POBJ_LAYOUT_ROOT(003_driver, driver_root_t);
+POBJ_LAYOUT_END(003_driver);
+
+
+TOID_DECLARE(uint64_t, TREE_MAP_TYPE_OFFSET + 2);
+
+int main(int argc, const char *argv[]) {
+
+  if (argc <= 2) {
+    fprintf(stderr, "%s: path n_entries\n", argv[0]);
+    return -1;
+  }
+
+  uint64_t n_entries = (uint64_t)atoi(argv[2]);
+  // (void*)pop is actually the mmap-ed region...
+  PMEMobjpool *pop = pmemobj_create(argv[1], POBJ_LAYOUT_NAME(003_driver), PMEMOBJ_MIN_POOL, 0666);
+  if (pop == NULL) {
+    printf("Create failed, trying open layout %s. (%s)\n", POBJ_LAYOUT_NAME(003_driver), strerror(errno));
+    pop = pmemobj_open(argv[1], POBJ_LAYOUT_NAME(003_driver));
+  }
+
+  if (pop == NULL) {
+    printf("Object pool is null! (%s)\n", strerror(errno));
+    exit(1);
+  }
+
+  printf("Getting root from pool (%p)...\n", pop);
+
+  TOID(driver_root_t) root = POBJ_ROOT(pop, driver_root_t);
+  
+  assert(!TOID_IS_NULL(root) && "Root is null!");
+  assert(TOID_VALID(root) && "Root is invalid!");
+  printf("\troot.oid.offset: %lu\n", root.oid.off);
+  printf("\troot._type: %p\n", root._type);
+  printf("\troot._type_num: %d\n", root._type_num);
+  assert(D_RO(root) && "Root direct is null!");
+
+  printf("Checking persistent state...\n");
+  TX_BEGIN(pop) {
+    printf("Asserting root is either null or valid...\n");
+    assert(TOID_IS_NULL(D_RO(root)->tree) || TOID_VALID(D_RO(root)->tree));
+    printf("Assertion passed!\n");
+
+    if (!TOID_IS_NULL(D_RO(root)->tree) && !tree_map_is_empty(D_RO(root)->tree)) {
+      printf("\t+ Removing old nodes...\n");
+      assert(!tree_map_clear(pop, D_RW(root)->tree) && "Could not clear tree!");
+      printf("\t+ Free-ing old allocation...\n");
+      TX_FREE(D_RW(root)->tree);
+    }
+
+    printf("\tChecking tree_map for old nodes...\n");
+    TX_SET(root, num_nodes, 0);
+    TX_SET(root, tree, TX_ZNEW(struct tree_map));
+    tree_map_new(pop, &D_RW(root)->tree);
+  } TX_END
+
+  printf("tree_map is now clean.\n");
+  printf("\tnum_nodes: %d\n", D_RO(root)->num_nodes);
+  printf("\ttree_map: %p\n", D_RO(D_RO(root)->tree));
+
+  int is_empty = tree_map_is_empty(D_RO(root)->tree);
+  printf("\5is_empty: %d\n", is_empty);
+
+  TX_BEGIN(pop) {
+    uint64_t i = 69;
+    TOID(uint64_t) val = TX_NEW(uint64_t);
+    TX_ADD(val);
+    *D_RW(val) = i;
+    assert(!tree_map_insert(pop, D_RW(root)->tree, i, val.oid));
+    TX_SET(root, num_nodes, D_RW(root)->num_nodes + 1);
+  } TX_END
+
+  /* for (uint64_t i = 0; i < n_entries; ++i) { */
+  /*   TX_BEGIN(pop) { */
+  /*     TOID(uint64_t) val = TX_NEW(uint64_t); */
+  /*     TX_ADD(val); */
+  /*     *D_RW(val) = i; */
+  /*     assert(!tree_map_insert(pop, D_RO(root)->tree, i, val.oid)); */
+  /*     TX_SET(root, num_nodes, D_RO(root)->num_nodes + 1); */
+  /*   } TX_END */
+  /*   printf("Size is now %lu!\n", D_RO(root)->num_nodes); */
+  /* } */
+
+  /* for (uint64_t i = 0; i < n_entries; ++i) { */
+  /*   PMEMoid val = tree_map_get(D_RO(root)->tree, i); */
+  /*   uint64_t *ptr = pmemobj_direct(val); */
+  /*   assert(OID_INSTANCEOF(val, uint64_t) && ptr && *ptr == i); */
+  /*   printf("\t%lu => %lu\n", i, *ptr); */
+  /* } */
+
+  printf("Closing and exiting now...\n");
+  pmemobj_close(pop);
+
+  return 0;
+}

--- a/nvmbugs/003_pmdk_rbtree_map/tree_map.h
+++ b/nvmbugs/003_pmdk_rbtree_map/tree_map.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * tree_map.c -- TreeMap sorted collection implementation
+ */
+
+#ifndef	TREE_MAP_H
+#define	TREE_MAP_H
+
+#include <libpmemobj.h>
+
+#define	TREE_MAP_TYPE_OFFSET 1000
+TOID_DECLARE(struct tree_map, TREE_MAP_TYPE_OFFSET + 0);
+
+struct tree_map;
+
+int tree_map_new(PMEMobjpool *pop, TOID(struct tree_map) *map);
+
+int tree_map_delete(PMEMobjpool *pop, TOID(struct tree_map) *map);
+
+int tree_map_insert(PMEMobjpool *pop,
+	TOID(struct tree_map) map, uint64_t key, PMEMoid value);
+
+int tree_map_insert_new(PMEMobjpool *pop,
+	TOID(struct tree_map) map, uint64_t key, size_t size,
+		unsigned int type_num,
+		void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg),
+		void *arg);
+
+PMEMoid tree_map_remove(PMEMobjpool *pop,
+	TOID(struct tree_map) map, uint64_t key);
+
+int tree_map_remove_free(PMEMobjpool *pop,
+	TOID(struct tree_map) map, uint64_t key);
+
+int tree_map_clear(PMEMobjpool *pop,
+	TOID(struct tree_map) map);
+
+PMEMoid tree_map_get(TOID(struct tree_map) map, uint64_t key);
+
+int tree_map_foreach(TOID(struct tree_map) map,
+	int (*cb)(uint64_t key, PMEMoid value, void *arg), void *arg);
+
+int tree_map_is_empty(TOID(struct tree_map) map);
+
+#endif /* TREE_MAP_H */

--- a/nvmbugs/CMakeLists.txt
+++ b/nvmbugs/CMakeLists.txt
@@ -78,4 +78,5 @@ add_custom_target(set_wllvm_env COMMAND export LLVM_COMPILER=clang; export LLVM_
 
 add_subdirectory(000_pmdk_btree_map)
 add_subdirectory(001_simple)
-add_subdirectory(002_simple_symbolic)
+#add_subdirectory(002_simple_symbolic)
+add_subdirectory(003_pmdk_rbtree_map)


### PR DESCRIPTION
PR consists of two main parts:

**Performance Issues**
Tool now catches performance issues (i.e. the unnecessary flushing of a clean cache line). Simply forks the state when about to invoke `persistCacheLineAtOffset` based on whether the cache line is already persisted, terminating on error in the failure state if possible. There are a suite of small test cases in nvmbugs/001_simple:
- `clean_flush_err.c`: tests flushing an offset which has never been written to
- `may_flush_err.c`: tests flushing an offset which _may_ (symbolic offset) have been written to
- `double_flush_err.c`: test flushing an offset which has already been flushed since a previous offset is on the same cache line
- `double_flush_no_err.c`: same as above, but offsets on different cache lines

These can be run simply with `./klee 001_CleanFlushErr.bc` or equivalent naming convention for the others.

I also modified  nvmbugs/000_pmdk_btree_map to attempt to catch the performance bug in btree which was reported in citation 30 in PMTest: [here](https://github.com/pmem/pmdk/commit/b9232407a794040102e769ed98b967d797c173fd#diff-f2692f0bb21a212d07a5d1bc2115c071)
This also involved modifying the driver to ensure the function in consideration actually gets hit (i.e. `btree_map_rotate_left`) as well as creating a new executable `000_Performance_Fixed` that patches this issue from `000_Clean`

**rbtree Reproduction**
Added nvmbugs/003_pmdk_rbtree_map to catch the persistence bug in rbtree which was reported in citation 25 in PMTest: [here](https://github.com/pmem/pmdk/commit/04ec84e23ed40be92bd89b9d34c39fbf28cafe0b#diff-f2692f0bb21a212d07a5d1bc2115c071)
Created a simple driver and two executables (one with the patch, one without) and noted that the executable with the patch (003_Clean) emitted one fewer persistence error than the executable without the patch (003_Buggy)