### PR TITLE
Improvements encountered during RECIPE

### DIFF
--- a/lib/Core/AddressSpace.h
+++ b/lib/Core/AddressSpace.h
@@ -56,6 +56,17 @@ namespace klee {
                              ref<Expr> p, const ObjectPair &op,
                              ResolutionList &rl, unsigned maxResolutions) const;
 
+    /// Check if the memory object in the given object pair overlaps the
+    /// range `[begin, end)`. If so, add it to the given resolution list.
+    ///
+    /// \return 1 iff the resolution is incomplete (`maxResolutions`
+    /// is non-zero and it was reached, or a query timed out), 0 iff
+    /// the resolution is complete (object is definitely in range),
+    /// and 2 otherwise.
+    int checkObjectInRange(ExecutionState &state, TimingSolver *solver,
+                           ref<Expr> begin, ref<Expr> end, const ObjectPair &op,
+                           ResolutionList &rl, unsigned maxResolutions) const;
+
   public:
     /// The MemoryObject -> ObjectState map that constitutes the
     /// address space.
@@ -102,6 +113,19 @@ namespace klee {
                  ResolutionList &rl, 
                  unsigned maxResolutions=0,
                  time::Span timeout=time::Span()) const;
+
+    /// Resolve range `[begin, end)` to a list of `ObjectPairs` that
+    /// could overlap that range. If `maxResolutions` is non-zero then
+    /// no more than that many pairs will be returned.
+    ///
+    /// \return true iff the resolution is incomplete (`maxResolutions`
+    /// is non-zero and it was reached, or a query timed out).
+    bool resolveRange(ExecutionState &state,
+                      TimingSolver *solver,
+                      ref<Expr> begin, ref<Expr> end,
+                      ResolutionList &rl, 
+                      unsigned maxResolutions=0,
+                      time::Span timeout=time::Span()) const;
 
     /***/
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -52,8 +52,8 @@ namespace klee {
 
 void ExecutionState::setupMain(KFunction *kf) {
   // single process, make its id always be 0
-  // the first thread, set its id to be 0
-  Thread mainThread = Thread(0, 0, kf);
+  // the first thread, set its id to be 1
+  Thread mainThread = Thread(1, 0, kf);
   threads.insert(std::make_pair(mainThread.tuid, mainThread));
   crtThreadIt = threads.begin();
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3331,6 +3331,8 @@ void Executor::terminateStateOnError(ExecutionState &state,
       msg << "assembly.ll line: " << ii.assemblyLine << "\n";
     }
 
+    // Print the call stack to both stdout and the .err file
+    state.dumpStack(msg);
     state.dumpStack(llvm::errs());
 
     std::string info_str = info.str();
@@ -4067,6 +4069,11 @@ bool Executor::getAllPersistenceErrors(ExecutionState &state,
   bool hasErr = false;
   if (state.persistentObjects.size()) {
     for (const MemoryObject *mo : state.persistentObjects) {
+      if (haltExecution) {
+        klee_warning("Halting execution while solving for persistence errors. "
+                     "Results will be incomplete.");
+        return hasErr;
+      }
       bool objHasErr = getPersistenceErrors(state, mo, errors);
       hasErr = hasErr || objHasErr;
     }

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -331,6 +331,10 @@ private:
 
   void executePersistentMemoryFlush(ExecutionState &state,
                                     ref<Expr> address);
+  void executePersistentMemoryFlush(ExecutionState &state,
+                                    const MemoryObject *mo,
+                                    PersistentState *ps,
+                                    ref<Expr> offset);
 
   void executePersistentMemoryFence(ExecutionState &state);
 

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -10,6 +10,8 @@
 #ifndef KLEE_MEMORYMANAGER_H
 #define KLEE_MEMORYMANAGER_H
 
+#include "klee/Expr/Expr.h"
+
 #include <cstddef>
 #include <set>
 #include <cstdint>
@@ -59,7 +61,9 @@ public:
   size_t getUsedDeterministicSize();
 
   size_t getCacheAlignment() const { return cacheAlignment; }
+  ref<Expr> getCacheAlignmentExpr(Expr::Width width=Expr::Int64) const;
   uint64_t alignToCache(uint64_t addr) const;
+  ref<Expr> alignToCache(ref<Expr> addr) const;
   size_t getSizeInCacheLines(size_t sizeInBytes) const;
 };
 

--- a/lib/Module/IntrinsicCleaner.cpp
+++ b/lib/Module/IntrinsicCleaner.cpp
@@ -73,6 +73,11 @@ bool IntrinsicCleanerPass::runOnBasicBlock(BasicBlock &b, Module &M) {
       case Intrinsic::x86_sse_sfence:
         break;
 
+        // Safely ignorable.
+      case Intrinsic::prefetch:
+        ii->eraseFromParent();
+        break;
+
         // Lower vacopy so that object resolution etc is handled by
         // normal instructions.
         //

--- a/nvmbugs/002_simple_symbolic/CMakeLists.txt
+++ b/nvmbugs/002_simple_symbolic/CMakeLists.txt
@@ -7,6 +7,12 @@ klee_add_test_object(
 ) 
 
 klee_add_test_object(
+  TARGET 002_SimpleSymbolic
+  SOURCES simple_symbolic.c
+  EXTRA_OPTIONS -mclwb
+) 
+
+klee_add_test_object(
   TARGET 002_TwoObjectTest
   SOURCES symbolic_two_object.c
   EXTRA_OPTIONS -mclwb

--- a/nvmbugs/002_simple_symbolic/simple_symbolic.c
+++ b/nvmbugs/002_simple_symbolic/simple_symbolic.c
@@ -1,0 +1,30 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+#include <assert.h>
+#include <immintrin.h>
+
+#include <klee/klee.h>
+
+int main() {
+	int size = 128;
+	char addr[size];
+	klee_pmem_mark_persistent(&addr, sizeof(addr), "addr");
+
+	int a, b;
+	klee_make_symbolic(&a, sizeof(a), "a");
+	klee_assume(0 <= a & a < size);
+	klee_make_symbolic(&b, sizeof(b), "b");
+	klee_assume(0 <= b & b < size);
+
+	//will only succeed if a and b on same cache-line
+	addr[a] = 'a';
+	_mm_clwb(&addr[b]);
+	_mm_sfence();
+
+	klee_pmem_check_persisted(&addr[a], sizeof(addr[a]));
+
+	return 0;
+}

--- a/runtime/POSIX/mman.c
+++ b/runtime/POSIX/mman.c
@@ -70,7 +70,7 @@ static int find_index(void *start, void *end) {
     mmap_entry_t *e = mmap_entries + i;
     if (e->start <= start && e->end >= end) {
       return i;
-    } else if (e->start <= start || e->end >= end) {
+    } else if (e->start < end && e->end > start) {
       klee_error("the desired unmap range partially overlaps!");
     }
   }

--- a/runtime/POSIX/mman.c
+++ b/runtime/POSIX/mman.c
@@ -285,6 +285,12 @@ int munmap(void *start, size_t length) {
 
   size_t pgsz = (size_t)getpagesize();
   start = __concretize_ptr(start);
+  // FIXME be able to partially unmap objects (to please jemalloc)
+  size_t pgoffset = (uintptr_t)start % pgsz;
+  if (pgoffset != 0) {
+    // Start on the next full page
+    start += (pgsz - pgoffset);
+  }
   void *addr;
   for (addr = start; addr < start + actual_size; addr += pgsz) {
     // snprintf(msg, 4096, "\tundef(addr=%p, length=%lu)", addr, pgsz);

--- a/runtime/POSIX/multiprocess.h
+++ b/runtime/POSIX/multiprocess.h
@@ -43,9 +43,6 @@
 #include "common.h"
 //#include "signals.h"
 
-
-#define DEFAULT_THREAD  0
-
 #define DEFAULT_PROCESS 2
 #define DEFAULT_PARENT  1
 #define DEFAULT_UMASK   (S_IWGRP | S_IWOTH)

--- a/runtime/POSIX/multiprocess_init.c
+++ b/runtime/POSIX/multiprocess_init.c
@@ -83,8 +83,8 @@ tsync_data_t __tsync;
 void klee_init_threads(void) {
   STATIC_LIST_INIT(__tsync.threads);
 
-  // Thread initialization
-  thread_data_t *def_data = &__tsync.threads[DEFAULT_THREAD];
+  // Initialize main thread's data
+  thread_data_t *def_data = &__tsync.threads[0];
   def_data->allocated = 1;
   def_data->terminated = 0;
   def_data->ret_value = 0;

--- a/runtime/POSIX/symfs.c
+++ b/runtime/POSIX/symfs.c
@@ -410,7 +410,9 @@ void klee_init_symfs(fs_init_descriptor_t *fid) {
   int i;
   for (i=0; i < n_sym_files; ++i) {
     disk_file_t *dfile = &__sym_fs.sym_files[i];
-    if (fid->sym_files[i].pmem_type != NOT_PMEM) {
+    dfile->pmem_type = fid->sym_files[i].pmem_type;
+
+    if (dfile->pmem_type != NOT_PMEM) {
       _create_pmem_file(dfile, &fid->sym_files[i], &def_stat);
       continue;
     }

--- a/runtime/POSIX/threadsync.c
+++ b/runtime/POSIX/threadsync.c
@@ -152,6 +152,7 @@ int pthread_mutex_destroy(pthread_mutex_t *mutex) {
   mutex_data_t *mdata = _get_mutex_data(mutex);
 
   free(mdata);
+  *((mutex_data_t**)mutex) = STATIC_MUTEX_VALUE;
 
   return 0;
 }
@@ -269,6 +270,7 @@ int pthread_cond_destroy(pthread_cond_t *cond) {
   condvar_data_t *cdata = _get_condvar_data(cond);
 
   free(cdata);
+  *((condvar_data_t**)cond) = STATIC_CVAR_VALUE;
 
   return 0;
 }
@@ -393,6 +395,7 @@ int pthread_barrier_destroy(pthread_barrier_t *barrier) {
   barrier_data_t *bdata = _get_barrier_data(barrier);
 
   free(bdata);
+  *((barrier_data_t**)barrier) = STATIC_BARRIER_VALUE;
 
   return 0;
 }
@@ -464,6 +467,7 @@ int pthread_rwlock_destroy(pthread_rwlock_t *rwlock) {
   rwlock_data_t *rwdata = _get_rwlock_data(rwlock);
 
   free(rwdata);
+  *((rwlock_data_t**)rwlock) = STATIC_RWLOCK_VALUE;
 
   return 0;
 }

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -835,6 +835,7 @@ static const char *modelledExternals[] = {
   "klee_stack_trace",
   "llvm.dbg.declare",
   "llvm.dbg.value",
+  "llvm.prefetch",
   "llvm.x86.clflushopt",
   "llvm.x86.clwb",
   "llvm.x86.sse2.clflush",


### PR DESCRIPTION
UPDATE: Rebased to be on top of Ian's big threading changes.

List of changes:

- Fix some issues with Ian's big threading changes
- Kind of a hacky thing to allow jemalloc library ctor to use our posix runtime
- Fix pthread_self() behavior enough to please jemalloc
- Passthrough `prefetch` intrinsics so I can run RECIPE
- Much more robust address resolution for `executePersistentMemoryFlush`