### PR TITLE
Generic TCP client simulation

### DIFF
--- a/runtime/Makefile.cmake.bitcode.config.in
+++ b/runtime/Makefile.cmake.bitcode.config.in
@@ -46,3 +46,5 @@ LLVMCC.Flags += $(LLVMCC.ExtraFlags) \
 	-D_DEBUG -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
 
 LLVMCC.Warnings += -Wall -Wwrite-strings
+
+SRC_DIRS := .

--- a/runtime/Makefile.cmake.bitcode.rules
+++ b/runtime/Makefile.cmake.bitcode.rules
@@ -81,14 +81,14 @@ endif
 # Compute the directory to put build files
 LOCAL_BUILD_DIR := $(abspath $(ROOT_OBJ)/$(DIR_SUFFIX))
 
-C_SRCS := $(sort $(shell echo $(SRC_DIR)/*.c))
+C_SRCS := $(foreach subdir,$(SRC_DIRS),$(sort $(shell echo $(SRC_DIR)/$(subdir)/*.c)))
 
 # Sanity check: Make sure at least one source file was found
 ifneq ($(strip $(filter %*.c,$(C_SRCS))),)
 $(error Failed to find C source files in $(SRC_DIR))
 endif
 
-C_SRCS_NO_DIR := $(notdir $(C_SRCS))
+C_SRCS_NO_DIR := $(subst $(SRC_DIR)/,,$(C_SRCS))
 BC_FILES_NO_DIR := $(C_SRCS_NO_DIR:.c=.bc)
 BC_FILES := $(addprefix $(LOCAL_BUILD_DIR)/,$(BC_FILES_NO_DIR))
 
@@ -114,7 +114,7 @@ $(BC_FILES) : $(ADDITIONAL_BUILD_DEPS) $(LLVMCC_FLAGS_FILE)
 # Pattern rule to build bitcode files
 $(LOCAL_BUILD_DIR)/%.bc : $(SRC_DIR)/%.c
 	@echo "LLVMCC ($(RUNTIME_CONFIG_STRING)) $<"
-	$(Verb) $(MKDIR) -p $(LOCAL_BUILD_DIR)
+	$(Verb) $(MKDIR) -p $(dir $@)
 	$(Verb) $(LLVMCC) $(LLVMCC.Flags) $(LLVMCC.Warnings) $< -c -o $@ -MP -MMD -MF $(LOCAL_BUILD_DIR)/$*.dep
 
 # $(LLVMCC_FLAGS_FILE) depends on `force` which will force the rule to

--- a/runtime/POSIX/Makefile.cmake.bitcode
+++ b/runtime/POSIX/Makefile.cmake.bitcode
@@ -12,4 +12,6 @@ include $(LEVEL)/Makefile.cmake.bitcode.config
 
 ARCHIVE_NAME=kleeRuntimePOSIX
 
+SRC_DIRS += socksim
+
 include $(LEVEL)/Makefile.cmake.bitcode.rules

--- a/runtime/POSIX/klee_init_env.c
+++ b/runtime/POSIX/klee_init_env.c
@@ -14,7 +14,7 @@
 #include "fd.h"
 #include "misc.h"
 #include "sockets.h"
-#include "sockets_simulator.h"
+#include "socksim/sockets_simulator.h"
 #include "symfs.h"
 #include "netlink.h"
 

--- a/runtime/POSIX/klee_init_env.c
+++ b/runtime/POSIX/klee_init_env.c
@@ -14,6 +14,7 @@
 #include "fd.h"
 #include "misc.h"
 #include "sockets.h"
+#include "socksim/client.h"
 #include "socksim/sockets_simulator.h"
 #include "symfs.h"
 #include "netlink.h"
@@ -113,6 +114,22 @@ static char help_msg[] =
 "                              rather than on environment init. Essentially, this allows\n"
 "                              us to create a new file which we know to mark symbolic.\n"
 "                              Implies that the file will be created with zeroed memory.\n"
+/* Sockets */
+"  -tcp-client-text <NAME> <PORT> <TEXT>\n"
+"                            - Creates a simulated TCP client that connects to\n"
+"                              localhost:<PORT>, sends <TEXT>, then closes.\n"
+"  -tcp-client-sym <NAME> <PORT> <N>\n"
+"                            - Creates a simulated TCP client that connects to\n"
+"                              localhost:<PORT>, sends a symbolic payload of\n"
+"                              size <N>, then closes.\n"
+// TODO
+// "  -tcp-client-file <NAME> <PORT> <FILE>\n"
+// "                            - Creates a simulated TCP client that connects to\n"
+// "                              localhost:<PORT> and sends the data contained in\n"
+// "                              <FILE>.\n"
+"  -sock-handler <NAME>      - Use predefined socket handler\n"
+"  -symbolic-sock-handler    - Inform socket handler that it is used during a\n"
+"                              symbolic replay. (default=false)\n"
 /* Other */
 "  -sym-stdin <N>            - Make stdin symbolic with size N.\n"
 "  -sym-file-stdin           - Make symbolic stdin behave like piped in from\n"
@@ -127,10 +144,7 @@ static char help_msg[] =
 "                              files.\n"
 "  -no-overlapped            - Do not keep per-state concrete file offsets\n"
 "  -fd-fail                  - Shortcut for '-max-fail 1'\n"
-"  -posix-debug              - Enable debug message in POSIX runtime\n"
-"  -sock-handler <NAME>      - Use predefined socket handler\n"
-"  -symbolic-sock-handler    - Inform socket handler that it is used during a\n"
-"                              symbolic replay. (default=false)\n";
+"  -posix-debug              - Enable debug message in POSIX runtime\n";
 
 static void __add_symfs_file(fs_init_descriptor_t *fid,
                              enum sym_file_type file_type,
@@ -147,6 +161,15 @@ static void __add_symfs_file(fs_init_descriptor_t *fid,
   sfd->pmem_type = pmem_type;
   sfd->file_path = file_path;
   sfd->file_size = file_size;
+}
+
+static void __add_socket_handler(socksim_init_descriptor_t *ssid,
+                                 socket_event_handler_t *handler) {
+  if (ssid->n_handlers >= MAX_SOCK_EVT_HANDLE) {
+    __emit_error("Maximum number of custom socket handlers reached.");
+  }
+
+  ssid->handlers[ssid->n_handlers++] = handler;
 }
 
 void klee_init_env(int *argcPtr, char ***argvPtr) {
@@ -171,9 +194,11 @@ void klee_init_env(int *argcPtr, char ***argvPtr) {
   fid.max_failures = 0;
   // This is defined in common.c
   enableDebug = 0;
+
+  socksim_init_descriptor_t ssid;
+  ssid.n_handlers = 0;
   // This is defined in sockets_simulator.c
   useSymbolicHandler = 0;
-  const char *sock_handler_name = NULL;
 
   sym_arg_name[5] = '\0';
 
@@ -325,6 +350,48 @@ void klee_init_env(int *argcPtr, char ***argvPtr) {
         __emit_error("--sym-pmem-delay file size cannot be 0\n");
       }
       __add_symfs_file(&fid, SYMBOLIC, PMEM_DELAY_CREATE, file_name, file_size);
+    } else if (__streq(argv[k], "--tcp-client-text") ||
+               __streq(argv[k], "-tcp-client-text")) {
+      const char *msg = "--tcp-client-text expects three arguments: "
+                "<NAME> <PORT> <TEXT>";
+      if (k + 3 >= argc) __emit_error(msg);
+      k++;
+      socket_event_handler_t *handler;
+      const char *name = argv[k++];
+      int port = (int)__str_to_int(argv[k++], msg);
+      const char *text = argv[k++];
+      handler = create_simple_text_client(name, port, text, strlen(text));
+      __add_socket_handler(&ssid, handler);
+    } else if (__streq(argv[k], "--tcp-client-sym") ||
+               __streq(argv[k], "-tcp-client-sym")) {
+      const char *msg = "--tcp-client-sym expects three arguments: "
+                "<NAME> <PORT> <N>";
+      if (k + 3 >= argc) __emit_error(msg);
+      k++;
+      socket_event_handler_t *handler;
+      const char *name = argv[k++];
+      int port = (int)__str_to_int(argv[k++], msg);
+      long size = __str_to_int(argv[k++], msg);
+      char *text = malloc(size);
+      klee_make_symbolic(text, size, name);
+      handler = create_simple_text_client(name, port, text, size);
+      __add_socket_handler(&ssid, handler);
+    } else if (__streq(argv[k], "--sock-handler") ||
+               __streq(argv[k], "-sock-handler")) {
+      const char *msg = "--sock-handler expects one string <NAME>";
+      if (k + 1 >= argc)
+        __emit_error(msg);
+      k++;
+      const char *name = argv[k++];
+      socket_event_handler_t *handler = get_predefined_socket_handler(name);
+      if (handler == NULL)
+        posix_debug_msg("Ignore unknown socket handler %s\n", name);
+      else
+        __add_socket_handler(&ssid, handler);
+    } else if (__streq(argv[k], "--symbolic-sock-handler") ||
+               __streq(argv[k], "-symbolic-sock-handler")) {
+      k++;
+      useSymbolicHandler = 1;
     } else if (__streq(argv[k], "--sym-stdin") ||
                __streq(argv[k], "-sym-stdin")) {
       const char *msg =
@@ -370,14 +437,6 @@ void klee_init_env(int *argcPtr, char ***argvPtr) {
                __streq(argv[k], "-posix-debug")) {
       k++;
       enableDebug = 1;
-    } else if (__streq(argv[k], "--sock-handler") ||
-               __streq(argv[k], "-sock-handler")) {
-      k++;
-      sock_handler_name = argv[k++];
-    } else if (__streq(argv[k], "--symbolic-sock-handler") ||
-               __streq(argv[k], "-symbolic-sock-handler")) {
-      k++;
-      useSymbolicHandler = 1;
     } else {
       /* simply copy arguments */
       __add_arg(&new_argc, new_argv, argv[k++], 1024);
@@ -403,12 +462,8 @@ void klee_init_env(int *argcPtr, char ***argvPtr) {
   // klee_init_mmap();
   klee_init_network();
   klee_init_netlink();
-  klee_init_sockets_simulator();
+  klee_init_sockets_simulator(&ssid);
   klee_init_threads();
-
-  if (sock_handler_name) {
-    register_predefined_socket_handler(sock_handler_name);
-  }
 }
 
 /* The following function represents the main function of the user application

--- a/runtime/POSIX/klee_init_env.c
+++ b/runtime/POSIX/klee_init_env.c
@@ -122,11 +122,10 @@ static char help_msg[] =
 "                            - Creates a simulated TCP client that connects to\n"
 "                              localhost:<PORT>, sends a symbolic payload of\n"
 "                              size <N>, then closes.\n"
-// TODO
-// "  -tcp-client-file <NAME> <PORT> <FILE>\n"
-// "                            - Creates a simulated TCP client that connects to\n"
-// "                              localhost:<PORT> and sends the data contained in\n"
-// "                              <FILE>.\n"
+"  -tcp-client-file <NAME> <PORT> <FILE>\n"
+"                            - Creates a simulated TCP client that connects to\n"
+"                              localhost:<PORT>, sends the data contained in\n"
+"                              <FILE>, then closes\n"
 "  -sock-handler <NAME>      - Use predefined socket handler\n"
 "  -symbolic-sock-handler    - Inform socket handler that it is used during a\n"
 "                              symbolic replay. (default=false)\n"
@@ -388,6 +387,18 @@ void klee_init_env(int *argcPtr, char ***argvPtr) {
         posix_debug_msg("Ignore unknown socket handler %s\n", name);
       else
         __add_socket_handler(&ssid, handler);
+    } else if (__streq(argv[k], "--tcp-client-file") ||
+               __streq(argv[k], "-tcp-client-file")) {
+      const char *msg = "--tcp-client-file expects three arguments: "
+                "<NAME> <PORT> <FILE>";
+      if (k + 3 >= argc) __emit_error(msg);
+      k++;
+      socket_event_handler_t *handler;
+      const char *name = argv[k++];
+      int port = (int)__str_to_int(argv[k++], msg);
+      const char *path = argv[k++];
+      handler = create_client_from_file(name, port, path);
+      __add_socket_handler(&ssid, handler);
     } else if (__streq(argv[k], "--symbolic-sock-handler") ||
                __streq(argv[k], "-symbolic-sock-handler")) {
       k++;

--- a/runtime/POSIX/sockets.c
+++ b/runtime/POSIX/sockets.c
@@ -38,7 +38,7 @@
 
 //#include "signals.h"
 #include "netlink.h"
-#include "sockets_simulator.h"
+#include "socksim/sockets_simulator.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/runtime/POSIX/socksim/client.c
+++ b/runtime/POSIX/socksim/client.c
@@ -1,0 +1,123 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "client.h"
+
+void simulated_client_handler_init(void *self) {
+  simulated_client_handler_t *self_hdl = (simulated_client_handler_t *)self;
+  self_hdl->client_sock = _create_socket(AF_INET, SOCK_STREAM, 0);
+  self_hdl->server_sock = NULL;
+}
+
+void simulated_client_handler_post_bind(void *self, socket_t *sock,
+                                        const struct sockaddr *addr,
+                                        socklen_t addrlen) {
+  simulated_client_handler_t *self_hdl = (simulated_client_handler_t*)self;
+  int server_port = self_hdl->server_port;
+
+  // We are only interested in socket bind to DEFAULT_ADDR:server_port
+  if (sock->domain != AF_INET) {
+    posix_debug_msg("simulated_client bind handler: no bind, not AF_INET\n");
+    return;
+  }
+  const struct sockaddr_in *inetaddr = (struct sockaddr_in*)addr;
+  if (inetaddr->sin_addr.s_addr != INADDR_ANY
+      && inetaddr->sin_addr.s_addr != htonl(INADDR_LOOPBACK)
+      && inetaddr->sin_addr.s_addr != __net.net_addr.s_addr) {
+    posix_debug_msg("simulated_client bind handler: no bind, bad saddr \n");
+    return;
+  }
+  if (inetaddr->sin_port != htons(server_port)) {
+    posix_debug_msg("simulated_client bind handler: no bind, bad port \n");
+    return;
+  }
+
+  self_hdl->server_sock = sock;
+  posix_debug_msg("simulated_client bind handler catch the server socket\n");
+}
+
+static void *connect_and_run_client(void *self) {
+  posix_debug_msg("Starting new simulated_client thread\n");
+  simulated_client_handler_t *self_hdl = (simulated_client_handler_t *)self;
+
+  struct sockaddr_in server_addr;
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_addr = __net.net_addr;
+  server_addr.sin_port = htons(self_hdl->server_port);
+  char server_addr_str[MAX_SOCK_ADDRSTRLEN];
+  _get_sockaddr_str(server_addr_str, sizeof(server_addr_str), AF_INET,
+                    (const struct sockaddr*)&server_addr);
+  posix_debug_msg("Attempting to connect to the server socket %s\n",
+                  server_addr_str);
+  int ret;
+  ret = _stream_connect(self_hdl->client_sock,
+                        (const struct sockaddr *)&server_addr,
+                        sizeof(server_addr));
+  assert(ret == 0 && "simulated_client listen handler fails to connect to "
+                      "the server socket");
+
+  // Call the client_func to actually do the client's work
+  self_hdl->client_func(self);
+
+  _close_socket(self_hdl->client_sock);
+  return NULL;
+}
+
+void simulated_client_handler_post_listen(void *self, socket_t *sock,
+                                          int backlog) {
+  simulated_client_handler_t *self_hdl = (simulated_client_handler_t *)self;
+  posix_debug_msg("simulated_client post listen handler self: %p\n", self_hdl);
+
+  if (self_hdl->server_sock && self_hdl->server_sock == sock) {
+    posix_debug_msg("simulated_client post listen handler create new thread\n");
+    pthread_t th;
+    int ret = pthread_create(&th, NULL, connect_and_run_client, (void*)self_hdl);
+    if (ret != 0) {
+      posix_debug_msg(
+          "simulated_client listen handler pthread failed with ret %d\n", ret);
+    }
+  }
+
+  (void)backlog;
+}
+
+/**
+ * Simple text client
+ */
+
+typedef struct {
+  simulated_client_handler_t __base;
+  const char *text;
+  unsigned len;
+} simple_text_client_handler_t;
+
+static void simple_text_client_func(void *self) {
+  socket_event_handler_t *base = (socket_event_handler_t *)self;
+  simulated_client_handler_t *client = (simulated_client_handler_t *)base;
+  simple_text_client_handler_t *text_client = (simple_text_client_handler_t *)base;
+
+  const char *payload = text_client->text;
+  const int len = text_client->len;
+
+  _write_socket(client->client_sock, payload, len);
+}
+
+socket_event_handler_t *
+create_simple_text_client(const char *name, int server_port,
+                          const char *text, unsigned len) {
+  simple_text_client_handler_t *handler;
+  handler = malloc(sizeof(*handler));
+
+  *handler = (simple_text_client_handler_t) {
+    .__base = SIMULATED_CLIENT_HANDLER(name,
+                                       server_port,
+                                       simple_text_client_func),
+    .text = text,
+    .len = len,
+  };
+
+  return (socket_event_handler_t *)handler;
+}
+

--- a/runtime/POSIX/socksim/client.h
+++ b/runtime/POSIX/socksim/client.h
@@ -54,4 +54,12 @@ socket_event_handler_t *
 create_simple_text_client(const char *name, int server_port,
                           const char *text, unsigned len);
 
+/**
+ * Creates a new simulated client handler that connects to `server_port`,
+ * sends the contents of the file at `path`, then closes.
+ */
+socket_event_handler_t *
+create_client_from_file(const char *name, int server_port,
+                        const char *path);
+
 #endif

--- a/runtime/POSIX/socksim/client.h
+++ b/runtime/POSIX/socksim/client.h
@@ -1,0 +1,57 @@
+/**
+ * This custom socket handler simulates a TCP client.
+ *
+ * When a socket binds to localhost on the given `server_port` and then listens,
+ * a client socket is created and connected on a separate thread to the server.
+ *
+ * Then, the spawned thread runs the provided `client_func`, passing it a
+ * pointer to its own simulated_client_handler_t.
+ *
+ * The most likely thing it will do is _write_socket to its `client_sock`.
+ */
+
+#ifndef SOCKSIM_CLIENT_H
+#define SOCKSIM_CLIENT_H
+
+#include "../sockets.h"
+#include "sockets_simulator.h"
+
+void simulated_client_handler_init(void *self);
+void simulated_client_handler_post_bind(void *self, socket_t *sock,
+                                        const struct sockaddr *addr,
+                                        socklen_t addrlen);
+void simulated_client_handler_post_listen(void *self, socket_t *sock,
+                                          int backlog);
+
+typedef void (*simulated_client_func_t)(void *);
+
+typedef struct {
+  socket_event_handler_t __base;
+  // Specified ahead of time.
+  int server_port;
+  simulated_client_func_t client_func;
+  // Set at runtime
+  socket_t *server_sock;
+  socket_t *client_sock;
+} simulated_client_handler_t;
+
+#define SIMULATED_CLIENT_HANDLER(_name, _port, _func) {    \
+  .__base = {                                              \
+    .name = _name,                                         \
+    .init = simulated_client_handler_init,                 \
+    .post_bind = simulated_client_handler_post_bind,       \
+    .post_listen = simulated_client_handler_post_listen,   \
+  },                                                       \
+  .server_port = _port,                                    \
+  .client_func = _func                                     \
+}
+
+/**
+ * Creates a new simulated client handler that connects to `server_port`,
+ * sends the payload `text` (length `len`), then closes.
+ */
+socket_event_handler_t *
+create_simple_text_client(const char *name, int server_port,
+                          const char *text, unsigned len);
+
+#endif

--- a/runtime/POSIX/socksim/memcached.c
+++ b/runtime/POSIX/socksim/memcached.c
@@ -4,8 +4,6 @@
 #include <stdio.h>
 #include <pthread.h>
 
-char useSymbolicHandler;
-
 #define MEMCACHED_PORT 11211
 
 typedef struct {
@@ -22,28 +20,13 @@ typedef struct {
 } memcached_update_handler_t;
 static memcached_update_handler_t memcached_update_handler;
 
-static socket_event_handler_t *all_handlers[] = {
-    (socket_event_handler_t *)(&memcached_1_5_13_handler),
-    (socket_event_handler_t *)(&memcached_update_handler)};
+// External references for sockets_simulator.c
 
-socket_simulator_t __sock_simulator;
-void register_predefined_socket_handler(const char *handler_name) {
-  int i;
-  for (i = 0; i < sizeof(all_handlers) / sizeof(all_handlers[0]); ++i) {
-    socket_event_handler_t *hdl = all_handlers[i];
-    if (strcmp(handler_name, hdl->name) == 0) {
-      __sock_simulator.handlers[__sock_simulator.registered_cnt++] = hdl;
-      hdl->init(hdl);
-      return;
-    }
-  }
-  posix_debug_msg("Ignore unknown socket handler %s\n", handler_name);
-}
+const socket_event_handler_t *const
+__memcached_1_5_13_handler = (const socket_event_handler_t *)&memcached_1_5_13_handler;
 
-void klee_init_sockets_simulator() {
-  __sock_simulator.registered_cnt = 0;
-  memset(__sock_simulator.handlers, 0, sizeof(__sock_simulator.handlers));
-}
+const socket_event_handler_t *const
+__memcached_update_handler = (const socket_event_handler_t *)&memcached_update_handler;
 
 /**
  * memcached 1.5.13 handler

--- a/runtime/POSIX/socksim/memcached.h
+++ b/runtime/POSIX/socksim/memcached.h
@@ -1,0 +1,14 @@
+#ifndef SOCKSIM_MEMCACHED_H_
+#define SOCKSIM_MEMCACHED_H_
+
+#include "client.h"
+
+/**
+ * Memcached socket simulators are basic simulated clients.
+ */
+typedef simulated_client_handler_t memcached_handler_t;
+
+extern memcached_handler_t __memcached_1_5_13_handler;
+extern memcached_handler_t __memcached_update_handler;
+
+#endif

--- a/runtime/POSIX/socksim/sockets_simulator.c
+++ b/runtime/POSIX/socksim/sockets_simulator.c
@@ -1,0 +1,31 @@
+#include "sockets_simulator.h"
+
+char useSymbolicHandler;
+socket_simulator_t __sock_simulator;
+
+extern const socket_event_handler_t *__memcached_1_5_13_handler;
+extern const socket_event_handler_t *__memcached_update_handler;
+
+static socket_event_handler_t *all_handlers[] = {
+    (socket_event_handler_t *)(&__memcached_1_5_13_handler),
+    (socket_event_handler_t *)(&__memcached_update_handler),
+};
+
+void klee_init_sockets_simulator() {
+  __sock_simulator.registered_cnt = 0;
+  memset(__sock_simulator.handlers, 0, sizeof(__sock_simulator.handlers));
+}
+
+void register_predefined_socket_handler(const char *handler_name) {
+  int i;
+  for (i = 0; i < sizeof(all_handlers) / sizeof(all_handlers[0]); ++i) {
+    socket_event_handler_t *hdl = all_handlers[i];
+    if (strcmp(handler_name, hdl->name) == 0) {
+      __sock_simulator.handlers[__sock_simulator.registered_cnt++] = hdl;
+      hdl->init(hdl);
+      return;
+    }
+  }
+  posix_debug_msg("Ignore unknown socket handler %s\n", handler_name);
+}
+

--- a/runtime/POSIX/socksim/sockets_simulator.c
+++ b/runtime/POSIX/socksim/sockets_simulator.c
@@ -1,31 +1,42 @@
+#include <assert.h>
+
+#include "memcached.h"
 #include "sockets_simulator.h"
 
 char useSymbolicHandler;
 socket_simulator_t __sock_simulator;
 
-extern const socket_event_handler_t *__memcached_1_5_13_handler;
-extern const socket_event_handler_t *__memcached_update_handler;
-
-static socket_event_handler_t *all_handlers[] = {
+static socket_event_handler_t *predefined_handlers[] = {
     (socket_event_handler_t *)(&__memcached_1_5_13_handler),
     (socket_event_handler_t *)(&__memcached_update_handler),
 };
 
-void klee_init_sockets_simulator() {
+void klee_init_sockets_simulator(const socksim_init_descriptor_t *ssid) {
   __sock_simulator.registered_cnt = 0;
   memset(__sock_simulator.handlers, 0, sizeof(__sock_simulator.handlers));
+
+  int i;
+  for (i = 0; i < ssid->n_handlers; ++i) {
+    register_socket_handler(ssid->handlers[i]);
+  }
 }
 
-void register_predefined_socket_handler(const char *handler_name) {
+void register_socket_handler(socket_event_handler_t *hdl) {
+  assert(__sock_simulator.registered_cnt < MAX_SOCK_EVT_HANDLE &&
+         "Too many registered socket event handlers!");
+  posix_debug_msg("Registering socket event handler: %s\n", hdl->name);
+  __sock_simulator.handlers[__sock_simulator.registered_cnt++] = hdl;
+  hdl->init(hdl);
+}
+
+socket_event_handler_t *get_predefined_socket_handler(const char *name) {
   int i;
-  for (i = 0; i < sizeof(all_handlers) / sizeof(all_handlers[0]); ++i) {
-    socket_event_handler_t *hdl = all_handlers[i];
-    if (strcmp(handler_name, hdl->name) == 0) {
-      __sock_simulator.handlers[__sock_simulator.registered_cnt++] = hdl;
-      hdl->init(hdl);
-      return;
+  for (i = 0; i < sizeof(predefined_handlers) / sizeof(predefined_handlers[0]); ++i) {
+    socket_event_handler_t *hdl = predefined_handlers[i];
+    if (strcmp(name, hdl->name) == 0) {
+      return hdl;
     }
   }
-  posix_debug_msg("Ignore unknown socket handler %s\n", handler_name);
+  return NULL;
 }
 

--- a/runtime/POSIX/socksim/sockets_simulator.h
+++ b/runtime/POSIX/socksim/sockets_simulator.h
@@ -1,6 +1,6 @@
 #ifndef SOCKETS_SIMULATOR_H_
 #define SOCKETS_SIMULATOR_H_
-#include "sockets.h"
+#include "../sockets.h"
 // This flag denotes if sockets simulator is used during a symbolic replay
 // Configurable in klee_init_env (option "-symbolic-sock-handler")
 extern char useSymbolicHandler;

--- a/runtime/POSIX/socksim/sockets_simulator.h
+++ b/runtime/POSIX/socksim/sockets_simulator.h
@@ -15,14 +15,24 @@ typedef struct {
   void (*post_listen)(void *self, socket_t *sock, int backlog);
 } socket_event_handler_t;
 
+// klee_init_env will pass this to klee_init_sockets_simulator 
+typedef struct {
+  unsigned n_handlers;
+  socket_event_handler_t *handlers[MAX_SOCK_EVT_HANDLE];
+} socksim_init_descriptor_t;
+
 typedef struct {
   unsigned int registered_cnt;
   socket_event_handler_t  *handlers[MAX_SOCK_EVT_HANDLE];
 } socket_simulator_t;
 extern socket_simulator_t __sock_simulator;
-void klee_init_sockets_simulator();
-// @return 1 if register successfully, 0 if not
-void register_predefined_socket_handler(const char *handler_name);
+void klee_init_sockets_simulator(const socksim_init_descriptor_t *ssid);
+void register_socket_handler(socket_event_handler_t *hdl);
+
+// To see an example of a predefined handler, see memcached.h, memcached.c,
+// and predefined_handlers inside sockets_simulator.c.
+// @return NULL if no predefined handler for given name
+socket_event_handler_t * get_predefined_socket_handler(const char *name);
 
 #define TRIGGER_SOCKET_HANDLER(handle, ...)                                    \
   do {                                                                         \


### PR DESCRIPTION
Created a new "subclass" of `socket_event_handler_t` called `simulated_client_handler_t`, which can be used to create new tcp workloads for different systems. The basic approach to doing this is:

1. Create new .h/.c files in `runtime/POSIX/socksim/`
2. Write a handler function that will run in a separate client thread and be given a connected client socket (i.e., `send()` here).
3. Expose an external struct that is based on `simulated_client_handler_t`, providing the expected port, the pointer to your handler function, and a unique name.
4. Add to the `predefined_handlers` array a pointer to your global struct.
5. Use `--sock-handler <name-of-your-handler>` when you run!

There are also two new convenient command line options for running a simulated TCP client without having to write more code:

```
  -tcp-client-text <NAME> <PORT> <TEXT>
                            - Creates a simulated TCP client that connects to
                              localhost:<PORT>, sends <TEXT>, then closes.
  -tcp-client-sym <NAME> <PORT> <N>
                            - Creates a simulated TCP client that connects to
                              localhost:<PORT>, sends a symbolic payload of
                              size <N>, then closes.
```